### PR TITLE
[release-v0.26] CI-Enablement Part-1: Adding files for generating artifacts and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,73 @@
+# This file is needed by kubebuilder but all functionality should exist inside
+# the hack/ files.
+
+CGO_ENABLED=0
+GOOS=linux
+# Ignore errors if there are no images.
+CORE_IMAGES=./control-plane/cmd/kafka-controller ./control-plane/cmd/webhook-kafka
+TEST_IMAGES=$(shell find ./test/test_images ./vendor/knative.dev/eventing/test/test_images -mindepth 1 -maxdepth 1 -type d 2> /dev/null)
+KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
+BRANCH=
+TEST=
+IMAGE=
+
+# Guess location of openshift/release repo. NOTE: override this if it is not correct.
+OPENSHIFT=${CURDIR}/../../github.com/openshift/release
+
+# Build and install commands.
+install:
+	for img in $(CORE_IMAGES); do \
+		go install $$img ; \
+	done
+.PHONY: install
+
+test-install:
+	for img in $(TEST_IMAGES); do \
+		go install $$img ; \
+	done
+.PHONY: test-install
+
+test-e2e:
+	sh openshift/e2e-tests.sh
+.PHONY: test-e2e
+
+# Requires ko 0.2.0 or newer.
+test-images:
+	for img in $(TEST_IMAGES); do \
+		ko resolve --tags=latest -RBf $$img ; \
+	done
+.PHONY: test-images
+
+test-image-single:
+	ko resolve --tags=latest -RBf test/test_images/$(IMAGE)
+.PHONY: test-image-single
+
+# Run make DOCKER_REPO_OVERRIDE=<your_repo> test-e2e-local if test images are available
+# in the given repository. Make sure you first build and push them there by running `make test-images`.
+# Run make BRANCH=<ci_promotion_name> test-e2e-local if test images from the latest CI
+# build for this branch should be used. Example: `make BRANCH=knative-v0.14.2 test-e2e-local`.
+# If neither DOCKER_REPO_OVERRIDE nor BRANCH are defined the tests will use test images
+# from the last nightly build.
+# If TEST is defined then only the single test will be run.
+test-e2e-local:
+	./openshift/e2e-tests-local.sh $(TEST)
+.PHONY: test-e2e-local
+
+# Generate Dockerfiles used by ci-operator. The files need to be committed manually.
+generate-dockerfiles:
+	rm -rf openshift/ci-operator/knative-images/*
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images $(CORE_IMAGES)
+	rm -rf openshift/ci-operator/knative-test-images/*
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-test-images $(TEST_IMAGES)
+.PHONY: generate-dockerfiles
+
+# Generate an aggregated knative release yaml file, as well as a CI file with replaced image references
+generate-release:
+	./openshift/release/generate-release.sh $(RELEASE)
+.PHONY: generate-release
+
+# Update CI configuration in the $(OPENSHIFT) directory.
+# NOTE: Makes changes outside this repository.
+update-ci:
+	sh ./openshift/ci-operator/update-ci.sh $(OPENSHIFT) $(CORE_IMAGES)
+.PHONY: update-ci

--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD ${bin} /usr/bin/${bin}
+ENTRYPOINT ["/usr/bin/${bin}"]

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,0 +1,13 @@
+# Dockerfile to bootstrap build and test in openshift-ci
+
+FROM registry.ci.openshift.org/openshift/release:golang-1.16
+
+# Add kubernetes repository
+ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
+
+RUN yum install -y kubectl ansible httpd-tools
+
+RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
+
+# Allow runtime users to add entries to /etc/passwd
+RUN chmod g+rw /etc/passwd

--- a/openshift/ci-operator/build-image/kubernetes.repo
+++ b/openshift/ci-operator/build-image/kubernetes.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+branch=${1-'knative-v0.26'}
+openshift=${2-'4.9'}
+promotion_disabled=${3-false}
+
+if [[ "$branch" == "knative-next" ]]; then
+    branch="knative-nightly"
+fi
+
+core_images=$(find ./openshift/ci-operator/knative-images -mindepth 1 -maxdepth 1 -type d | LC_COLLATE=posix sort)
+test_images=$(find ./openshift/ci-operator/knative-test-images -mindepth 1 -maxdepth 1 -type d | LC_COLLATE=posix sort)
+
+function print_image_dependencies {
+  for img in $core_images; do
+    image_base=knative-eventing-kafka-broker-$(basename $img)
+    to_image=$(echo ${image_base//[_.]/-})
+    to_image=$(echo ${to_image//v0/upgrade-v0})
+    to_image=$(echo ${to_image//migrate/storage-version-migration})
+    to_image=$(echo ${to_image//kafka-kafka-/kafka-})
+    image_env=$(echo ${to_image//-/_})
+    image_env=$(echo ${image_env^^})
+    cat <<EOF
+      - env: $image_env
+        name: $to_image
+EOF
+  done
+
+  for img in $test_images; do
+    image_base=knative-eventing-kafka-broker-test-$(basename $img)
+    to_image=$(echo ${image_base//_/-})
+    image_env=$(echo ${to_image//-/_})
+    image_env=$(echo ${image_env^^})
+    cat <<EOF
+      - env: $image_env
+        name: $to_image
+EOF
+  done
+}
+
+image_deps=$(print_image_dependencies)
+
+cat <<EOF
+promotion:
+  additional_images:
+    knative-eventing-kafka-broker-src: src
+  disabled: $promotion_disabled
+  cluster: https://api.ci.openshift.org
+  namespace: openshift
+  name: $branch.0
+releases:
+  initial:
+    integration:
+      name: "$openshift"
+      namespace: ocp
+  latest:
+    integration:
+      include_built_images: true
+      name: "$openshift"
+      namespace: ocp
+base_images:
+  base:
+    name: '$openshift'
+    namespace: ocp
+    tag: base
+build_root:
+  project_image:
+    dockerfile_path: openshift/ci-operator/build-image/Dockerfile
+canonical_go_repository: knative.dev/eventing-kafka-broker
+binary_build_commands: make install
+test_binary_build_commands: make test-install
+tests:
+- as: e2e-aws-ocp-${openshift//./}
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    owner: openshift-ci
+    product: ocp
+    timeout: 1h0m0s
+    version: "$openshift"
+  steps:
+    test:
+    - as: test
+      cli: latest
+      commands: make test-e2e
+      dependencies:
+$image_deps
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+      timeout: 4h0m0s
+    workflow: generic-claim
+- as: e2e-aws-ocp-${openshift//./}-continuous
+  cluster_claim:
+    architecture: amd64
+    cloud: aws
+    owner: openshift-ci
+    product: ocp
+    timeout: 1h0m0s
+    version: "$openshift"
+  cron: 0 */12 * * 1-5
+  steps:
+    test:
+    - as: test
+      cli: latest
+      commands: make test-e2e
+      dependencies:
+$image_deps
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+      timeout: 4h0m0s
+    workflow: generic-claim
+resources:
+  '*':
+    limits:
+      memory: 6Gi
+    requests:
+      cpu: 4
+      memory: 6Gi
+  'bin':
+    limits:
+      memory: 6Gi
+    requests:
+      cpu: 4
+      memory: 6Gi
+images:
+EOF
+
+for img in $core_images; do
+  image_base=$(basename $img)
+  to_image=$(echo ${image_base//[_.]/-})
+  to_image=$(echo ${to_image//v0/upgrade-v0})
+  to_image=$(echo ${to_image//migrate/storage-version-migration})
+  to_image=$(echo ${to_image//kafka-kafka-/kafka-})
+  cat <<EOF
+- dockerfile_path: openshift/ci-operator/knative-images/$image_base/Dockerfile
+  from: base
+  inputs:
+    bin:
+      paths:
+      - destination_dir: .
+        source_path: /go/bin/$image_base
+  to: knative-eventing-kafka-broker-$to_image
+EOF
+done
+
+for img in $test_images; do
+  image_base=$(basename $img)
+  to_image=$(echo ${image_base//_/-})
+  cat <<EOF
+- dockerfile_path: openshift/ci-operator/knative-test-images/$image_base/Dockerfile
+  from: base
+  inputs:
+    test-bin:
+      paths:
+      - destination_dir: .
+        source_path: /go/bin/$image_base
+  to: knative-eventing-kafka-broker-test-$to_image
+EOF
+done

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+function generate_dockefiles() {
+  local target_dir=$1; shift
+  # Remove old images and re-generate, avoid stale images hanging around.
+  for img in $@; do
+    local image_base=$(basename $img)
+    mkdir -p $target_dir/$image_base
+    bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+  done
+}
+
+generate_dockefiles $@

--- a/openshift/ci-operator/knative-images/kafka-controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/kafka-controller/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD kafka-controller /usr/bin/kafka-controller
+ENTRYPOINT ["/usr/bin/kafka-controller"]

--- a/openshift/ci-operator/knative-images/webhook-kafka/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook-kafka/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD webhook-kafka /usr/bin/webhook-kafka
+ENTRYPOINT ["/usr/bin/webhook-kafka"]

--- a/openshift/ci-operator/knative-test-images/committed-offset/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/committed-offset/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD committed-offset /usr/bin/committed-offset
+ENTRYPOINT ["/usr/bin/committed-offset"]

--- a/openshift/ci-operator/knative-test-images/consumer-group-lag-provider-test/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/consumer-group-lag-provider-test/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD consumer-group-lag-provider-test /usr/bin/consumer-group-lag-provider-test
+ENTRYPOINT ["/usr/bin/consumer-group-lag-provider-test"]

--- a/openshift/ci-operator/knative-test-images/event-flaker/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/event-flaker/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD event-flaker /usr/bin/event-flaker
+ENTRYPOINT ["/usr/bin/event-flaker"]

--- a/openshift/ci-operator/knative-test-images/event-library/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/event-library/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD event-library /usr/bin/event-library
+ENTRYPOINT ["/usr/bin/event-library"]

--- a/openshift/ci-operator/knative-test-images/event-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/event-sender/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD event-sender /usr/bin/event-sender
+ENTRYPOINT ["/usr/bin/event-sender"]

--- a/openshift/ci-operator/knative-test-images/heartbeats/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/heartbeats/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD heartbeats /usr/bin/heartbeats
+ENTRYPOINT ["/usr/bin/heartbeats"]

--- a/openshift/ci-operator/knative-test-images/kafka-consumer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/kafka-consumer/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD kafka-consumer /usr/bin/kafka-consumer
+ENTRYPOINT ["/usr/bin/kafka-consumer"]

--- a/openshift/ci-operator/knative-test-images/partitions-replication-verifier/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/partitions-replication-verifier/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD partitions-replication-verifier /usr/bin/partitions-replication-verifier
+ENTRYPOINT ["/usr/bin/partitions-replication-verifier"]

--- a/openshift/ci-operator/knative-test-images/performance/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/performance/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD performance /usr/bin/performance
+ENTRYPOINT ["/usr/bin/performance"]

--- a/openshift/ci-operator/knative-test-images/print/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/print/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD print /usr/bin/print
+ENTRYPOINT ["/usr/bin/print"]

--- a/openshift/ci-operator/knative-test-images/recordevents/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/recordevents/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD recordevents /usr/bin/recordevents
+ENTRYPOINT ["/usr/bin/recordevents"]

--- a/openshift/ci-operator/knative-test-images/request-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/request-sender/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM openshift/origin-base
+
+ADD request-sender /usr/bin/request-sender
+ENTRYPOINT ["/usr/bin/request-sender"]

--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -1,0 +1,1 @@
+FROM src

--- a/openshift/ci-operator/update-ci.sh
+++ b/openshift/ci-operator/update-ci.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# A script that will update the mapping file in github.com/openshift/release
+
+set -e
+readonly TMPDIR=$(mktemp -d knativeEventingPeriodicReporterXXXX -p /tmp/)
+fail() { echo; echo "$*"; exit 1; }
+
+cat >> "$TMPDIR"/reporterConfig <<EOF
+  reporter_config:
+    slack:
+      channel: '#knative-eventing'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}} :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :volcano: {{end}}'
+EOF
+
+
+# Deduce X.Y version from branch name
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+VERSION=$(echo $BRANCH | sed -E 's/^.*(v[0-9]+\.[0-9]+|next)|.*/\1/')
+test -n "$VERSION" || fail "'$BRANCH' is not a release branch"
+VER=$(echo $VERSION | sed 's/\./_/;s/\.[0-9]\+$//') # X_Y form of version
+
+
+# Set up variables for important locations in the openshift/release repo.
+OPENSHIFT=$(realpath "$1"); shift
+test -d "$OPENSHIFT/.git" || fail "'$OPENSHIFT' is not a git repo"
+MIRROR="$OPENSHIFT/core-services/image-mirroring/knative/mapping_knative_${VER}_quay"
+CONFIGDIR=$OPENSHIFT/ci-operator/config/openshift-knative/eventing-kafka-broker
+test -d "$CONFIGDIR" || fail "'$CONFIGDIR' is not a directory"
+PERIODIC_CONFIGDIR=$OPENSHIFT/ci-operator/jobs/openshift-knative/eventing-kafka-broker
+test -d "$PERIODIC_CONFIGDIR" || fail "'$PERIODIC_CONFIGDIR' is not a directory"
+
+# Generate CI config files
+CONFIG=$CONFIGDIR/openshift-knative-eventing-kafka-broker-release-$VERSION
+PERIODIC_CONFIG=$PERIODIC_CONFIGDIR/openshift-knative-eventing-kafka-broker-release-$VERSION-periodics.yaml
+CURDIR=$(dirname $0)
+$CURDIR/generate-ci-config.sh knative-$VERSION 4.9 > ${CONFIG}__49.yaml
+
+# Switch to openshift/release to generate PROW files
+cd $OPENSHIFT
+echo "Generating PROW files in $OPENSHIFT"
+make jobs
+make ci-operator-config
+# We have to do this manually, see: https://docs.ci.openshift.org/docs/how-tos/notification/
+echo "==== Adding reporter_config to periodics ===="
+# These version MUST match the ocp version we used above
+for OCP_VERSION in 47; do
+    sed -i "/  name: periodic-ci-openshift-knative-eventing-kafka-broker-release-${VERSION}-${OCP_VERSION}-e2e-aws-ocp-${OCP_VERSION}-continuous\n  spec:/ r $TMPDIR/reporterConfig" "$PERIODIC_CONFIG"
+done
+echo "==== Changes made to $OPENSHIFT ===="
+git status
+echo "==== Commit changes to $OPENSHIFT and create a PR"


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Part 1: adding the skeleton for generating CI config, and allowing us to get image builds from control-plane

Missing: data-plane images, e2e tests and setup...

