### PR TITLE
Patch min. version for OCP 4.6

### DIFF
--- a/vendor/knative.dev/pkg/version/version.go
+++ b/vendor/knative.dev/pkg/version/version.go
@@ -33,7 +33,7 @@ const (
 	// NOTE: If you are changing this line, please also update the minimum kubernetes
 	// version listed here:
 	// https://github.com/knative/docs/blob/mkdocs/docs/snippets/prerequisites.md
-	defaultMinimumVersion = "v1.20.0"
+	defaultMinimumVersion = "v1.19.0"
 )
 
 func getMinimumVersion() string {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Doing https://github.com/openshift/knative-eventing/pull/1470  for here too...


/hold

not sure if we should merge that ... now ... 