### PR TITLE
Adding install base for running CI... part I

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+function scale_up_workers(){
+  local cluster_api_ns="openshift-machine-api"
+
+  oc get machineset -n ${cluster_api_ns} --show-labels
+
+  # Get the name of the first machineset that has at least 1 replica
+  local machineset
+  machineset=$(oc get machineset -n ${cluster_api_ns} -o custom-columns="name:{.metadata.name},replicas:{.spec.replicas}" | grep " 1" | head -n 1 | awk '{print $1}')
+  # Bump the number of replicas to 6 (+ 1 + 1 == 8 workers)
+  oc patch machineset -n ${cluster_api_ns} "${machineset}" -p '{"spec":{"replicas":6}}' --type=merge
+  wait_until_machineset_scales_up ${cluster_api_ns} "${machineset}" 6
+}
+
+# Waits until the machineset in the given namespaces scales up to the
+# desired number of replicas
+# Parameters: $1 - namespace
+#             $2 - machineset name
+#             $3 - desired number of replicas
+function wait_until_machineset_scales_up() {
+  echo -n "Waiting until machineset $2 in namespace $1 scales up to $3 replicas"
+  for _ in {1..150}; do  # timeout after 15 minutes
+    local available
+    available=$(oc get machineset -n "$1" "$2" -o jsonpath="{.status.availableReplicas}")
+    if [[ ${available} -eq $3 ]]; then
+      echo -e "\nMachineSet $2 in namespace $1 successfully scaled up to $3 replicas"
+      return 0
+    fi
+    echo -n "."
+    sleep 6
+  done
+  echo - "Error: timeout waiting for machineset $2 in namespace $1 to scale up to $3 replicas"
+  return 1
+}
+
+# Loops until duration (car) is exceeded or command (cdr) returns non-zero
+function timeout() {
+  SECONDS=0; TIMEOUT=$1; shift
+  while eval $*; do
+    sleep 5
+    [[ $SECONDS -gt $TIMEOUT ]] && echo "ERROR: Timed out" && return 1
+  done
+  return 0
+}
+
+function kafka_setup() {
+  echo ">> Prepare to deploy Strimzi"
+  ./test/kafka/kafka_setup.sh || fail_test "Failed to set up Kafka cluster"
+}
+
+function install_serverless(){
+  header "Installing Serverless Operator"
+  local operator_dir=/tmp/serverless-operator
+  local failed=0
+  git clone --branch release-1.19 https://github.com/openshift-knative/serverless-operator.git $operator_dir || return 1
+  # unset OPENSHIFT_BUILD_NAMESPACE (old CI) and OPENSHIFT_CI (new CI) as its used in serverless-operator's CI
+  # environment as a switch to use CI built images, we want pre-built images of k-s-o and k-o-i
+  unset OPENSHIFT_BUILD_NAMESPACE
+  unset OPENSHIFT_CI
+  pushd $operator_dir
+
+  ./hack/install.sh && header "Serverless Operator installed successfully" || failed=1
+  popd
+  return $failed
+}

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")/../vendor/knative.dev/hack/e2e-tests.sh"
+source "$(dirname "$0")/e2e-common.sh"
+
+set -Eeuox pipefail
+
+##export TEST_IMAGE_TEMPLATE="${EVENTING_KAFKA_TEST_IMAGE_TEMPLATE}"
+
+env
+
+scale_up_workers || exit 1
+
+failed=0
+
+(( !failed )) && kafka_setup || failed=1
+
+(( !failed )) && install_serverless || failed=1
+
+# (( !failed )) && install_knative_kafka || failed=1
+
+# (( !failed )) && install_tracing || failed=1
+
+# (( !failed )) && run_e2e_tests || failed=1
+
+(( failed )) && dump_cluster_state
+
+(( failed )) && exit 1
+
+success


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

this adds scripts to install "Serverless" and Kafka

More to come:
* Part II: enable on Prow
* Part III replace images
* Part IV see the e2e run