### PR TITLE
Using UBI 8 with Java-17 image as Runtime

### DIFF
--- a/openshift/ci-operator/knative-images/broker-dispatcher/Dockerfile
+++ b/openshift/ci-operator/knative-images/broker-dispatcher/Dockerfile
@@ -43,7 +43,8 @@ RUN ./generate_jdk.sh /build/dispatcher/target/dispatcher-1.0-SNAPSHOT.jar
 
 RUN cp /build/dispatcher/target/dispatcher-1.0-SNAPSHOT.jar /app/app.jar
 
-FROM quay.io/openshift-knative/17-jdk-centos7 as running
+# We use the generated JDK from the "builder" image, so we can just go with the ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as running
 
 COPY --from=builder /app /app
 

--- a/openshift/ci-operator/knative-images/broker-receiver/Dockerfile
+++ b/openshift/ci-operator/knative-images/broker-receiver/Dockerfile
@@ -40,7 +40,8 @@ RUN ./generate_jdk.sh /build/receiver/target/receiver-1.0-SNAPSHOT.jar
 
 RUN cp /build/receiver/target/receiver-1.0-SNAPSHOT.jar /app/app.jar
 
-FROM quay.io/openshift-knative/17-jdk-centos7 as running
+# We use the generated JDK from the "builder" image, so we can just go with the ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as running
 
 COPY --from=builder /app /app
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

As per title, and closing https://github.com/openshift-knative/eventing-kafka-broker/pull/42

Just using the `ubi minimal` 