### PR TITLE
[release-v1.0] Using sink receiver

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -123,7 +123,8 @@ EOF
   DP_RELEASE_YAML="openshift/release/knative-eventing-kafka-broker-dp-ci.yaml"
 
   sed -i -e "s|registry.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-broker-dispatcher|${KNATIVE_EVENTING_KAFKA_BROKER_DISPATCHER}|g" ${DP_RELEASE_YAML}
-  sed -i -e "s|registry.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-broker-receiver|${KNATIVE_EVENTING_KAFKA_BROKER_RECEIVER}|g"       ${DP_RELEASE_YAML}
+  sed -i -e "s|registry.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-broker-receiver|${KNATIVE_EVENTING_KAFKA_BROKER_RECEIVER}|g"     ${DP_RELEASE_YAML}
+  sed -i -e "s|registry.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-broker-receiver|${KNATIVE_EVENTING_KAFKA_SINK_RECEIVER}|g"       ${DP_RELEASE_YAML}
 
   oc apply -f ${DP_RELEASE_YAML}
   wait_until_pods_running $EVENTING_NAMESPACE || return 1

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -8,10 +8,10 @@ broker_cp_output_file="openshift/release/knative-eventing-kafka-broker-cp-ci.yam
 broker_dp_output_file="openshift/release/knative-eventing-kafka-broker-dp-ci.yaml"
 
 if [ "$release" == "ci" ]; then
-    image_prefix="registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-kafka-broker-"
+    image_prefix="registry.ci.openshift.org/openshift/knative-nightly:knative-eventing-kafka-"
     tag=""
 else
-    image_prefix="registry.ci.openshift.org/openshift/knative-${release}:knative-eventing-kafka-broker-"
+    image_prefix="registry.ci.openshift.org/openshift/knative-${release}:knative-eventing-kafka-"
     tag=""
 fi
 

--- a/openshift/release/knative-eventing-kafka-broker-dp-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-broker-dp-ci.yaml
@@ -517,7 +517,7 @@ spec:
               weight: 100
       containers:
         - name: kafka-sink-receiver
-          image: registry.ci.openshift.org/openshift/knative-v1.0.0:knative-eventing-kafka-broker-receiver
+          image: registry.ci.openshift.org/openshift/knative-v1.0.0:knative-eventing-kafka-sink-receiver
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -21,10 +21,10 @@ function resolve_resources(){
     sed -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(test/\)\(.*\)+\1\2 \3\4test-\5+g" \
         -e "s+ko://++" \
         -e "s+contrib.eventing.knative.dev/release: devel+contrib.eventing.knative.dev/release: ${release}+" \
-        -e "s+\${KNATIVE_KAFKA_BROKER_DISPATCHER_IMAGE}+${image_prefix}dispatcher${image_tag}+" \
-        -e "s+\${KNATIVE_KAFKA_BROKER_RECEIVER_IMAGE}+${image_prefix}receiver${image_tag}+" \
-        -e "s+\${KNATIVE_KAFKA_SINK_RECEIVER_IMAGE}+${image_prefix}receiver${image_tag}+" \
-        -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \
+        -e "s+\${KNATIVE_KAFKA_BROKER_DISPATCHER_IMAGE}+${image_prefix}broker-dispatcher${image_tag}+" \
+        -e "s+\${KNATIVE_KAFKA_BROKER_RECEIVER_IMAGE}+${image_prefix}broker-receiver${image_tag}+" \
+        -e "s+\${KNATIVE_KAFKA_SINK_RECEIVER_IMAGE}+${image_prefix}sink-receiver${image_tag}+" \
+        -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}broker-\4${image_tag}+g" \
         -e '/^[ \t]*#/d' \
         -e '/^[ \t]*$/d' \
         "$yaml" >> $resolved_file_name


### PR DESCRIPTION
Updating the generator to ensure we use the proper `sink-receiver` and use explict `-broker` or `-sink` prefixes

/assign @pierDipi 