### PR TITLE
[release-v0.26] Download zipkin from Github's container registry

### DIFF
--- a/test/config/monitoring.yaml
+++ b/test/config/monitoring.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: docker.io/openzipkin/zipkin:2.13.0
+        image: ghcr.io/openzipkin/zipkin:2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9411


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

manual backport of https://github.com/knative-sandbox/eventing-kafka-broker/pull/1270

/assign @pierDipi 