### PR TITLE
[release-0.26] Add client value to --dry-run command line argument

### DIFF
--- a/test/kafka/kafka_setup.sh
+++ b/test/kafka/kafka_setup.sh
@@ -18,7 +18,7 @@ set -e
 
 source $(dirname $0)/../../vendor/knative.dev/hack/e2e-tests.sh
 
-kubectl create namespace kafka --dry-run -o yaml | kubectl apply -f -
+kubectl create namespace kafka --dry-run=client -o yaml | kubectl apply -f -
 
 sleep 5
 


### PR DESCRIPTION
This is breaking the build in https://github.com/openshift-knative/eventing-kafka-broker/pull/59