### PR TITLE
Add KafkaSink upgrade tests (#1716)

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -101,6 +101,8 @@ function install_latest_release() {
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_BROKER_ARTIFACT}" || return $?
   kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_SINK_ARTIFACT}" || return $?
+  kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_SOURCE_ARTIFACT}" || return $?
+  # kubectl apply -f "${PREVIOUS_RELEASE_URL}/${EVENTING_KAFKA_CHANNEL_ARTIFACT}" || return $?
 }
 
 function install_head() {

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -21,6 +21,15 @@ readonly SKIP_INITIALIZE=${SKIP_INITIALIZE:-false}
 
 source $(dirname $0)/e2e-common.sh
 
+# Override test_setup from e2e-common since we don't want to apply the latest release
+# before running the upgrade test.
+function test_setup() {
+  build_components_from_source || return $?
+
+  # Apply test configurations, and restart data plane components (we don't have hot reload)
+  ko apply -f ./test/config/ || fail_test "Failed to apply test configurations"
+}
+
 if ! ${SKIP_INITIALIZE}; then
   initialize $@ --skip-istio-addon
   save_release_artifacts || fail_test "Failed to save release artifacts"

--- a/test/e2e/kafka_sink.go
+++ b/test/e2e/kafka_sink.go
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	testlib "knative.dev/eventing/test/lib"
+
+	eventingv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	eventingv1alpha1clientset "knative.dev/eventing-kafka-broker/control-plane/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/test/pkg/addressable"
+	"knative.dev/eventing-kafka-broker/test/pkg/sink"
+
+	. "knative.dev/eventing-kafka-broker/test/pkg/testing"
+)
+
+const (
+	sinkSecretName = "secret-test"
+)
+
+func RunTestKafkaSink(t *testing.T, mode string, sp SecretProvider, opts ...func(kss *eventingv1alpha1.KafkaSinkSpec) error) {
+	RunMultiple(t, func(t *testing.T) {
+
+		ctx := context.Background()
+
+		const (
+			kafkaSinkName = "kafka-sink"
+		)
+
+		client := testlib.Setup(t, false)
+		defer testlib.TearDown(client)
+
+		clientSet, err := eventingv1alpha1clientset.NewForConfig(client.Config)
+		require.Nil(t, err)
+
+		// Create a KafkaSink with the following spec.
+
+		kss := eventingv1alpha1.KafkaSinkSpec{
+			Topic:             "kafka-sink-" + client.Namespace,
+			NumPartitions:     pointer.Int32Ptr(10),
+			ReplicationFactor: func(rf int16) *int16 { return &rf }(1),
+			BootstrapServers:  BootstrapServersPlaintextArr,
+			ContentMode:       pointer.StringPtr(mode),
+		}
+		for _, opt := range opts {
+			require.Nil(t, opt(&kss))
+		}
+
+		t.Logf("%+v", kss)
+
+		if sp != nil {
+			secretData := sp(t, client)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: client.Namespace,
+					Name:      sinkSecretName,
+				},
+				Data: secretData,
+			}
+			secret, err = client.Kube.CoreV1().Secrets(client.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+			require.Nil(t, err)
+			client.Tracker.Add(corev1.GroupName, "v1", "Secret", secret.Namespace, secret.Name)
+		}
+
+		createFunc := sink.CreatorV1Alpha1(clientSet, kss)
+
+		kafkaSink, err := createFunc(types.NamespacedName{
+			Namespace: client.Namespace,
+			Name:      kafkaSinkName,
+		})
+		require.Nil(t, err)
+
+		ks, err := clientSet.KafkaSinks(client.Namespace).Get(ctx, kafkaSinkName, metav1.GetOptions{})
+		require.Nil(t, err)
+		client.Tracker.AddObj(ks)
+
+		client.WaitForResourceReadyOrFail(kafkaSink.Name, &kafkaSink.TypeMeta)
+
+		// Send events to the KafkaSink.
+		ids := addressable.Send(t, kafkaSink)
+
+		// Read events from the topic.
+		sink.Verify(t, client, mode, kss.Topic, ids)
+	})
+}

--- a/test/e2e/kafka_sink_test.go
+++ b/test/e2e/kafka_sink_test.go
@@ -20,122 +20,43 @@
 package e2e
 
 import (
-	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
-	testlib "knative.dev/eventing/test/lib"
 
 	eventingv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
-	eventingv1alpha1clientset "knative.dev/eventing-kafka-broker/control-plane/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
-	"knative.dev/eventing-kafka-broker/test/pkg/addressable"
-	"knative.dev/eventing-kafka-broker/test/pkg/sink"
 	. "knative.dev/eventing-kafka-broker/test/pkg/testing"
 )
 
-const (
-	sinkSecretName = "secret-test"
-)
-
 func TestKafkaSinkV1Alpha1DefaultContentMode(t *testing.T) {
-	testKafkaSink(t, eventingv1alpha1.ModeStructured, nil, func(kss *eventingv1alpha1.KafkaSinkSpec) error {
+	RunTestKafkaSink(t, eventingv1alpha1.ModeStructured, nil, func(kss *eventingv1alpha1.KafkaSinkSpec) error {
 		kss.ContentMode = pointer.StringPtr("")
 		return nil
 	})
 }
 
 func TestKafkaSinkV1Alpha1StructuredContentMode(t *testing.T) {
-	testKafkaSink(t, eventingv1alpha1.ModeStructured, nil)
+	RunTestKafkaSink(t, eventingv1alpha1.ModeStructured, nil)
 }
 
 func TestKafkaSinkV1Alpha1BinaryContentMode(t *testing.T) {
-	testKafkaSink(t, eventingv1alpha1.ModeBinary, nil)
+	RunTestKafkaSink(t, eventingv1alpha1.ModeBinary, nil)
 }
 
 func TestKafkaSinkV1Alpha1AuthPlaintext(t *testing.T) {
-	testKafkaSink(t, eventingv1alpha1.ModeStructured, Plaintext, withBootstrap(BootstrapServersPlaintextArr), withSecret)
+	RunTestKafkaSink(t, eventingv1alpha1.ModeStructured, Plaintext, withBootstrap(BootstrapServersPlaintextArr), withSecret)
 }
 
 func TestKafkaSinkV1Alpha1AuthSsl(t *testing.T) {
-	testKafkaSink(t, eventingv1alpha1.ModeStructured, Ssl, withBootstrap(BootstrapServersSslArr), withSecret)
+	RunTestKafkaSink(t, eventingv1alpha1.ModeStructured, Ssl, withBootstrap(BootstrapServersSslArr), withSecret)
 }
 
 func TestKafkaSinkV1Alpha1AuthSaslPlaintextScram512(t *testing.T) {
-	testKafkaSink(t, eventingv1alpha1.ModeStructured, SaslPlaintextScram512, withBootstrap(BootstrapServersSaslPlaintextArr), withSecret)
+	RunTestKafkaSink(t, eventingv1alpha1.ModeStructured, SaslPlaintextScram512, withBootstrap(BootstrapServersSaslPlaintextArr), withSecret)
 }
 
 func TestKafkaSinkV1Alpha1AuthSslSaslScram512(t *testing.T) {
-	testKafkaSink(t, eventingv1alpha1.ModeStructured, SslSaslScram512, withBootstrap(BootstrapServersSslSaslScramArr), withSecret)
-}
-
-func testKafkaSink(t *testing.T, mode string, sp SecretProvider, opts ...func(kss *eventingv1alpha1.KafkaSinkSpec) error) {
-	RunMultiple(t, func(t *testing.T) {
-
-		ctx := context.Background()
-
-		const (
-			kafkaSinkName = "kafka-sink"
-		)
-
-		client := testlib.Setup(t, false)
-		defer testlib.TearDown(client)
-
-		clientSet, err := eventingv1alpha1clientset.NewForConfig(client.Config)
-		require.Nil(t, err)
-
-		// Create a KafkaSink with the following spec.
-
-		kss := eventingv1alpha1.KafkaSinkSpec{
-			Topic:             "kafka-sink-" + client.Namespace,
-			NumPartitions:     pointer.Int32Ptr(10),
-			ReplicationFactor: func(rf int16) *int16 { return &rf }(1),
-			BootstrapServers:  BootstrapServersPlaintextArr,
-			ContentMode:       pointer.StringPtr(mode),
-		}
-		for _, opt := range opts {
-			require.Nil(t, opt(&kss))
-		}
-
-		t.Log(kss)
-
-		if sp != nil {
-			secretData := sp(t, client)
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: client.Namespace,
-					Name:      sinkSecretName,
-				},
-				Data: secretData,
-			}
-			secret, err = client.Kube.CoreV1().Secrets(client.Namespace).Create(ctx, secret, metav1.CreateOptions{})
-			require.Nil(t, err)
-			client.Tracker.Add(corev1.GroupName, "v1", "Secret", secret.Namespace, secret.Name)
-		}
-
-		createFunc := sink.CreatorV1Alpha1(clientSet, kss)
-
-		kafkaSink, err := createFunc(types.NamespacedName{
-			Namespace: client.Namespace,
-			Name:      kafkaSinkName,
-		})
-		require.Nil(t, err)
-
-		ks, err := clientSet.KafkaSinks(client.Namespace).Get(ctx, kafkaSinkName, metav1.GetOptions{})
-		require.Nil(t, err)
-		client.Tracker.AddObj(ks)
-
-		client.WaitForResourceReadyOrFail(kafkaSink.Name, &kafkaSink.TypeMeta)
-
-		// Send events to the KafkaSink.
-		ids := addressable.Send(t, kafkaSink)
-
-		// Read events from the topic.
-		sink.Verify(t, client, mode, kss.Topic, ids)
-	})
+	RunTestKafkaSink(t, eventingv1alpha1.ModeStructured, SslSaslScram512, withBootstrap(BootstrapServersSslSaslScramArr), withSecret)
 }
 
 func withSecret(kss *eventingv1alpha1.KafkaSinkSpec) error {

--- a/test/upgrade/continual.go
+++ b/test/upgrade/continual.go
@@ -22,11 +22,27 @@ import (
 	"knative.dev/eventing-kafka-broker/test/upgrade/continual"
 )
 
+// ContinualTests returns all continual tests.
+func ContinualTests() []pkgupgrade.BackgroundOperation {
+	c := BrokerContinualTests()
+	c = append(c, SinkContinualTests()...)
+	return c
+}
+
 // BrokerContinualTests returns background operations to test broker
 // functionality in continual manner during the whole upgrade and downgrade
 // process asserting that all events are propagated.
 func BrokerContinualTests() []pkgupgrade.BackgroundOperation {
 	return []pkgupgrade.BackgroundOperation{
 		continual.BrokerTest(continual.KafkaBrokerTestOptions{}),
+	}
+}
+
+// SinkContinualTests returns background operations to test KafkaSink
+// functionality in continual manner during the whole upgrade and downgrade
+// process asserting that all events are propagated.
+func SinkContinualTests() []pkgupgrade.BackgroundOperation {
+	return []pkgupgrade.BackgroundOperation{
+		continual.SinkSourceTest(continual.KafkaSinkSourceTestOptions{}),
 	}
 }

--- a/test/upgrade/continual/kafka-sink-source-config.toml
+++ b/test/upgrade/continual/kafka-sink-source-config.toml
@@ -1,0 +1,7 @@
+# logLevel = 'DEBUG'
+[sender]
+address = '{{- .Endpoint -}}'
+interval = {{ .Config.Interval.Nanoseconds }}
+
+[forwarder]
+target = 'http://wathola-receiver.{{- .Namespace -}}.svc.cluster.local'

--- a/test/upgrade/continual/sink_source.go
+++ b/test/upgrade/continual/sink_source.go
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2022 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package continual
+
+import (
+	"fmt"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	bindings "knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1"
+	sources "knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
+	eventingkafkaupgrade "knative.dev/eventing-kafka/test/upgrade/continual"
+	"knative.dev/eventing/test/upgrade/prober/sut"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	pkgupgrade "knative.dev/pkg/test/upgrade"
+
+	eventingkafkatestlib "knative.dev/eventing-kafka/test/lib"
+
+	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	eventingv1alpha1clientset "knative.dev/eventing-kafka-broker/control-plane/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/test/pkg/sink"
+	testingpkg "knative.dev/eventing-kafka-broker/test/pkg/testing"
+)
+
+const (
+	kafkaSinkConfigTemplate = "test/upgrade/continual/kafka-sink-source-config.toml"
+
+	defaultTopic = "kafka-sink-source-continual-test-topic"
+)
+
+type KafkaSinkSourceTestOptions struct {
+	*eventingkafkaupgrade.TestOptions
+	*Sink
+	*Source
+}
+
+func (o *KafkaSinkSourceTestOptions) setDefaults() {
+	if o.TestOptions == nil {
+		o.TestOptions = &eventingkafkaupgrade.TestOptions{}
+	}
+	if o.Sink == nil {
+		rf := int16(3)
+		o.Sink = &Sink{
+			Name: "sink-kafka-sink-source-continual-test",
+			Spec: eventing.KafkaSinkSpec{
+				Topic:             defaultTopic,
+				NumPartitions:     pointer.Int32(10),
+				ReplicationFactor: &rf,
+				BootstrapServers:  []string{testingpkg.BootstrapServersPlaintext},
+			},
+		}
+	}
+	if o.Source == nil {
+		o.Source = &Source{
+			Name: "source-kafka-sink-source-continual-test",
+			Spec: sources.KafkaSourceSpec{
+				Topics:        []string{defaultTopic},
+				ConsumerGroup: "source-kafka-sink-source-continual-test-consumer-group",
+				InitialOffset: sources.OffsetEarliest,
+				KafkaAuthSpec: bindings.KafkaAuthSpec{
+					BootstrapServers: []string{testingpkg.BootstrapServersPlaintext},
+				},
+			},
+		}
+	}
+}
+
+func (o *KafkaSinkSourceTestOptions) validate() error {
+	if len(o.Source.Spec.Topics) != 1 || o.Sink.Spec.Topic != o.Source.Spec.Topics[0] {
+		return fmt.Errorf("expected sink and source topic to be the same topic, source topics %v, sink topic %v", o.Source.Spec.Topics, o.Sink.Spec.Topic)
+	}
+	return nil
+}
+
+type kafkaSinkSourceSut struct {
+	Sink
+	Source
+}
+
+func (k kafkaSinkSourceSut) Deploy(ctx sut.Context, destination duckv1.Destination) interface{} {
+	k.deploySink(ctx)
+	k.deploySource(ctx, destination)
+	url := k.fetchUrl(ctx)
+	return url
+}
+
+func (k kafkaSinkSourceSut) deploySink(ctx sut.Context) {
+	clientSet, err := eventingv1alpha1clientset.NewForConfig(ctx.Config)
+	require.Nil(ctx.T, err)
+
+	s := types.NamespacedName{
+		Namespace: ctx.Client.Namespace,
+		Name:      k.Sink.Name,
+	}
+	if _, err = sink.CreatorV1Alpha1(clientSet, k.Sink.Spec)(s); err != nil {
+		ctx.T.Fatalf("failed to create KafkaSink %+v: %v", s, err)
+	}
+}
+
+func (k kafkaSinkSourceSut) deploySource(ctx sut.Context, destination duckv1.Destination) {
+	ks := &sources.KafkaSource{
+		TypeMeta: metav1.TypeMeta{Kind: "KafkaSource", APIVersion: sources.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k.Source.Name,
+			Namespace: ctx.Client.Namespace,
+		},
+		Spec: *k.Source.Spec.DeepCopy(),
+	}
+	ks.Spec.Sink = destination
+	eventingkafkatestlib.CreateKafkaSourceV1Beta1OrFail(ctx.Client, ks)
+}
+
+func (k kafkaSinkSourceSut) fetchUrl(ctx sut.Context) *apis.URL {
+	tm := &metav1.TypeMeta{
+		Kind:       "KafkaSink",
+		APIVersion: eventing.SchemeGroupVersion.String(),
+	}
+	ctx.Client.WaitForResourceReadyOrFail(k.Sink.Name, tm)
+	address, err := ctx.Client.GetAddressableURI(k.Sink.Name, tm)
+	require.Nil(ctx.T, err, "Failed to get address from sink %s", k.Sink.Name)
+
+	url, _ := apis.ParseURL(address)
+	return url
+}
+
+func SinkSourceTest(opts KafkaSinkSourceTestOptions) pkgupgrade.BackgroundOperation {
+	opts.setDefaults()
+	if err := opts.validate(); err != nil {
+		panic(err)
+	}
+	return continualVerification(
+		"KafkaSinkSourceContinualTest",
+		opts.TestOptions,
+		&kafkaSinkSourceSut{Sink: *opts.Sink, Source: *opts.Source},
+		kafkaSinkConfigTemplate,
+	)
+}

--- a/test/upgrade/continual/types.go
+++ b/test/upgrade/continual/types.go
@@ -17,10 +17,13 @@
 package continual
 
 import (
+	sources "knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
 	eventingkafkaupgrade "knative.dev/eventing-kafka/test/upgrade/continual"
 	"knative.dev/eventing/test/upgrade/prober"
 	"knative.dev/eventing/test/upgrade/prober/sut"
 	"knative.dev/eventing/test/upgrade/prober/wathola/event"
+
+	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
 )
 
 // TestOptions holds options for EventingKafka continual tests.
@@ -37,6 +40,16 @@ type Broker struct {
 	Name string
 	*eventingkafkaupgrade.ReplicationOptions
 	*eventingkafkaupgrade.RetryOptions
+}
+
+type Sink struct {
+	Name string
+	Spec eventing.KafkaSinkSpec
+}
+
+type Source struct {
+	Name string
+	Spec sources.KafkaSourceSpec
 }
 
 var eventTypes = []string{

--- a/test/upgrade/postdowngrade.go
+++ b/test/upgrade/postdowngrade.go
@@ -18,6 +18,9 @@ package upgrade
 
 import (
 	pkgupgrade "knative.dev/pkg/test/upgrade"
+
+	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/test/e2e"
 )
 
 // BrokerPostDowngradeTest tests channel basic channel operations after
@@ -25,5 +28,12 @@ import (
 func BrokerPostDowngradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("BrokerPostDowngradeTest", func(c pkgupgrade.Context) {
 		runBrokerSmokeTest(c.T)
+	})
+}
+
+// SinkPostDowngradeTest tests sink basic operations after downgrade.
+func SinkPostDowngradeTest() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation("SinkPostDowngradeTest", func(c pkgupgrade.Context) {
+		e2e.RunTestKafkaSink(c.T, eventing.ModeBinary, nil)
 	})
 }

--- a/test/upgrade/postupgrade.go
+++ b/test/upgrade/postupgrade.go
@@ -18,11 +18,21 @@ package upgrade
 
 import (
 	pkgupgrade "knative.dev/pkg/test/upgrade"
+
+	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/test/e2e"
 )
 
 // BrokerPostUpgradeTest tests channel operations after upgrade.
 func BrokerPostUpgradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("BrokerPostUpgradeTest", func(c pkgupgrade.Context) {
 		runBrokerSmokeTest(c.T)
+	})
+}
+
+// SinkPostUpgradeTest tests sink basic operations post upgrade.
+func SinkPostUpgradeTest() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation("SinkPostDowngradeTest", func(c pkgupgrade.Context) {
+		e2e.RunTestKafkaSink(c.T, eventing.ModeBinary, nil)
 	})
 }

--- a/test/upgrade/preupgrade.go
+++ b/test/upgrade/preupgrade.go
@@ -18,11 +18,21 @@ package upgrade
 
 import (
 	pkgupgrade "knative.dev/pkg/test/upgrade"
+
+	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/test/e2e"
 )
 
 // BrokerPreUpgradeTest tests channel operations before upgrade.
 func BrokerPreUpgradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("BrokerPreUpgradeTest", func(c pkgupgrade.Context) {
 		runBrokerSmokeTest(c.T)
+	})
+}
+
+// SinkPreUpgradeTest tests sink basic operations pre upgrade.
+func SinkPreUpgradeTest() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation("SinkPostDowngradeTest", func(c pkgupgrade.Context) {
+		e2e.RunTestKafkaSink(c.T, eventing.ModeBinary, nil)
 	})
 }

--- a/test/upgrade/suite.go
+++ b/test/upgrade/suite.go
@@ -28,14 +28,17 @@ func Suite() pkgupgrade.Suite {
 		Tests: pkgupgrade.Tests{
 			PreUpgrade: []pkgupgrade.Operation{
 				BrokerPreUpgradeTest(),
+				SinkPreUpgradeTest(),
 			},
 			PostUpgrade: []pkgupgrade.Operation{
 				BrokerPostUpgradeTest(),
+				SinkPostUpgradeTest(),
 			},
 			PostDowngrade: []pkgupgrade.Operation{
 				BrokerPostDowngradeTest(),
+				SinkPostDowngradeTest(),
 			},
-			Continual: BrokerContinualTests(),
+			Continual: ContinualTests(),
 		},
 		Installations: pkgupgrade.Installations{
 			Base: []pkgupgrade.Operation{


### PR DESCRIPTION
Cherry-pick of https://github.com/knative-sandbox/eventing-kafka-broker/pull/1716

Note: we cannot cherry-pick this commit in the respective upstream branch (`1.0`)
since the test is based on the `KafkaSource` implementation which wasn't available
upstream until v1.1