### PR TITLE
:dizzy: using flags, since we already use that via ParseAndGetRESTConfigOrDie

### DIFF
--- a/vendor/knative.dev/pkg/injection/sharedmain/main.go
+++ b/vendor/knative.dev/pkg/injection/sharedmain/main.go
@@ -24,9 +24,8 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
-
-	"github.com/spf13/pflag"
 
 	"go.uber.org/automaxprocs/maxprocs" // automatically set GOMAXPROCS based on cgroups
 	"go.uber.org/zap"
@@ -120,12 +119,15 @@ var (
 // by name.
 func MainNamed(ctx context.Context, component string, ctors ...injection.NamedControllerConstructor) {
 
-	disabledControllers := pflag.StringSlice("disable-controllers", []string{}, "Comma-separated list of disabled controllers.")
+	var (
+		disabledControllers string
+	)
+	flag.StringVar(&disabledControllers, "disable-controllers", "", "Comma-separated list of disabled controllers.")
 
 	// HACK: This parses flags, so the above should be set once this runs.
 	cfg := injection.ParseAndGetRESTConfigOrDie()
 
-	enabledCtors := enabledControllers(*disabledControllers, ctors)
+	enabledCtors := enabledControllers(strings.Split(disabledControllers, ","), ctors)
 
 	MainWithConfig(ctx, component, cfg, toControllerConstructors(enabledCtors)...)
 }


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Similar to #65  with out this patch, and a `disable-controllers` ARG, I get:

```shell
    Args:
      --disable-controllers=source-controller
    State:       Waiting
      Reason:    CrashLoopBackOff
    Last State:  Terminated
      Reason:    Error
      Message:   flag provided but not defined: -disable-controllers
```

Patching here, since https://github.com/knative/pkg/pull/2379/commits/798325101e01844dd418295d57714c063393be0a was not merged.... will revisit.

But without this -> not working 
