### PR TITLE
Reuse of different patches stashing them on `main` branch

### DIFF
--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -28,6 +28,7 @@ function print_image_dependencies {
     to_image=$(echo ${to_image//v0/upgrade-v0})
     to_image=$(echo ${to_image//migrate/storage-version-migration})
     to_image=$(echo ${to_image//kafka-kafka-/kafka-})
+    to_image=$(echo ${to_image//broker-broker-/broker-})
     image_env=$(echo ${to_image//-/_})
     image_env=$(echo ${image_env^^})
     cat <<EOF

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -124,7 +124,6 @@ EOF
 
   sed -i -e "s|registry.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-broker-dispatcher|${KNATIVE_EVENTING_KAFKA_BROKER_DISPATCHER}|g" ${DP_RELEASE_YAML}
   sed -i -e "s|registry.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-broker-receiver|${KNATIVE_EVENTING_KAFKA_BROKER_RECEIVER}|g"     ${DP_RELEASE_YAML}
-  sed -i -e "s|registry.ci.openshift.org/openshift/knative-.*:knative-eventing-kafka-broker-receiver|${KNATIVE_EVENTING_KAFKA_SINK_RECEIVER}|g"       ${DP_RELEASE_YAML}
 
   oc apply -f ${DP_RELEASE_YAML}
   wait_until_pods_running $EVENTING_NAMESPACE || return 1

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -23,6 +23,10 @@ resolve_resources control-plane/config/100-sink cp_sink.yaml $image_prefix $tag
 cat cp_sink.yaml >> $broker_cp_output_file
 rm cp_sink.yaml
 
+resolve_resources control-plane/config/100-source cp_source.yaml $image_prefix $tag
+cat cp_source.yaml >> $broker_cp_output_file
+rm cp_source.yaml
+
 resolve_resources control-plane/config/200-controller cp_broker.yaml $image_prefix $tag
 cat cp_broker.yaml >> $broker_cp_output_file
 rm cp_broker.yaml
@@ -31,23 +35,17 @@ cat cp_broker.yaml >> $broker_cp_output_file
 rm cp_broker.yaml
 
 # the Broker Data Plane folders
-# The generic DP root folder
-resolve_resources data-plane/config $broker_dp_output_file $image_prefix $tag
-
 # The DP folder for Broker:
-resolve_resources data-plane/config/broker dp_broker.yaml $image_prefix $tag
-cat dp_broker.yaml >> $broker_dp_output_file
-rm dp_broker.yaml
-
-resolve_resources data-plane/config/broker/template dp_broker.yaml $image_prefix $tag
-cat dp_broker.yaml >> $broker_dp_output_file
-rm dp_broker.yaml
+resolve_resources data-plane/config/broker $broker_dp_output_file $image_prefix
+# cat dp_broker.yaml >> $broker_dp_output_file
+# rm dp_broker.yaml
 
 # The DP folder for Sink:
 resolve_resources data-plane/config/sink dp_sink.yaml $image_prefix $tag
 cat dp_sink.yaml >> $broker_dp_output_file
 rm dp_sink.yaml
 
-resolve_resources data-plane/config/sink/template dp_sink.yaml $image_prefix $tag
-cat dp_sink.yaml >> $broker_dp_output_file
-rm dp_sink.yaml
+# The DP folder for Source:
+resolve_resources data-plane/config/source dp_source.yaml $image_prefix $tag
+cat dp_source.yaml >> $broker_dp_output_file
+rm dp_source.yaml

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -21,9 +21,8 @@ function resolve_resources(){
     sed -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(test/\)\(.*\)+\1\2 \3\4test-\5+g" \
         -e "s+ko://++" \
         -e "s+contrib.eventing.knative.dev/release: devel+contrib.eventing.knative.dev/release: ${release}+" \
-        -e "s+\${KNATIVE_KAFKA_BROKER_DISPATCHER_IMAGE}+${image_prefix}broker-dispatcher${image_tag}+" \
-        -e "s+\${KNATIVE_KAFKA_BROKER_RECEIVER_IMAGE}+${image_prefix}broker-receiver${image_tag}+" \
-        -e "s+\${KNATIVE_KAFKA_SINK_RECEIVER_IMAGE}+${image_prefix}sink-receiver${image_tag}+" \
+        -e "s+\${KNATIVE_KAFKA_DISPATCHER_IMAGE}+${image_prefix}broker-dispatcher${image_tag}+" \
+        -e "s+\${KNATIVE_KAFKA_RECEIVER_IMAGE}+${image_prefix}broker-receiver${image_tag}+" \
         -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}broker-\4${image_tag}+g" \
         -e '/^[ \t]*#/d' \
         -e '/^[ \t]*$/d' \


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

As per title.

Here is a list of commits, where I used the different patches for our _scripts_ (not on generated files):

* https://github.com/openshift-knative/eventing-kafka-broker/commit/1caea011e697b118b514553d2ed5fe30da438805#diff-d1f6a0b482e1186e9e185284cbc46751b4d0ddd6c510abeadc21ce798ee192d6
* https://github.com/openshift-knative/eventing-kafka-broker/commit/9e02488963ff1c6b6f01f5dda8fa9895a2c82ab8#diff-d1f6a0b482e1186e9e185284cbc46751b4d0ddd6c510abeadc21ce798ee192d6
* https://github.com/openshift-knative/eventing-kafka-broker/commit/eed13f2ec2243c920aaab378c53c2c0d6918668a#diff-d1f6a0b482e1186e9e185284cbc46751b4d0ddd6c510abeadc21ce798ee192d6
* https://github.com/openshift-knative/eventing-kafka-broker/commit/85b5a1cb476bf6ccfe35597b860c5ac8dfdff84f#diff-d1f6a0b482e1186e9e185284cbc46751b4d0ddd6c510abeadc21ce798ee192d6

**NOTE:** This is a prerequisite for creating 1.2 branch, and later the `release-next` automation 