### PR TITLE
[`main`] Adding channel to the DP generator

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -49,3 +49,8 @@ rm dp_sink.yaml
 resolve_resources data-plane/config/source dp_source.yaml $image_prefix $tag
 cat dp_source.yaml >> $broker_dp_output_file
 rm dp_source.yaml
+
+# The DP folder for Channel:
+resolve_resources data-plane/config/channel dp_channel.yaml $image_prefix $tag
+cat dp_channel.yaml >> $broker_dp_output_file
+rm dp_channel.yaml


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

as per title, and script part of https://github.com/openshift-knative/eventing-kafka-broker/pull/85  ported to `main`


/assign @pierDipi 
