### PR TITLE
Do not remove existing Dockerfiles before generating new ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,7 @@ test-e2e-local:
 
 # Generate Dockerfiles used by ci-operator. The files need to be committed manually.
 generate-dockerfiles:
-	rm -rf openshift/ci-operator/knative-images/*
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images $(CONTROL_PLANE_IMAGES)
-	rm -rf openshift/ci-operator/knative-test-images/*
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-test-images $(TEST_IMAGES)
 .PHONY: generate-dockerfiles
 


### PR DESCRIPTION
* There are static images brought by
https://github.com/openshift-knative/eventing-kafka-broker/commit/f006911ce1048c7f1ef18dc42b51c5228d3dd0a4
* They should not be deleted when generating new Dockerfiles from
update-to-head.sh script

The bug prevents from running CI against release-next branch as pursued here: https://github.com/openshift/release/pull/26046
Example error: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/26046/rehearse-26046-pull-ci-openshift-knative-eventing-kafka-broker-release-next-49-conformance-aws-ocp-49/1490705034487271424
