### PR TITLE
Do not remove comments when resolving yaml files for CI

### DIFF
--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -24,7 +24,6 @@ function resolve_resources(){
         -e "s+\${KNATIVE_KAFKA_DISPATCHER_IMAGE}+${image_prefix}broker-dispatcher${image_tag}+" \
         -e "s+\${KNATIVE_KAFKA_RECEIVER_IMAGE}+${image_prefix}broker-receiver${image_tag}+" \
         -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}broker-\4${image_tag}+g" \
-        -e '/^[ \t]*#/d' \
         -e '/^[ \t]*$/d' \
         "$yaml" >> $resolved_file_name
   done


### PR DESCRIPTION
* YAML allows the following syntax when xyz is actually still taken as
as a comment. But removing the line with the # sign will cause a failure
when applying this yaml file because xyz is suddenly not a comment.

```
data:
  _example: |
    #
      xyz
```

We use this pattern e.g. here:
https://github.com/knative-sandbox/eventing-kafka-broker/blob/e32c88296d90f95a99d15a0dc649a9238e1ee819/control-plane/config/200-controller/100-config-kafka-descheduler.yaml#L43