### PR TITLE
Process 100-channel and 100-kafka-internal

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -19,6 +19,14 @@ fi
 # The generic CP root folder
 resolve_resources control-plane/config/100-broker $broker_cp_output_file $image_prefix $tag
 
+resolve_resources control-plane/config/100-channel cp_channel.yaml $image_prefix $tag
+cat cp_channel.yaml >> $broker_cp_output_file
+rm cp_channel.yaml
+
+resolve_resources control-plane/config/100-kafka-internal cp_kafka_internal.yaml $image_prefix $tag
+cat cp_kafka_internal.yaml >> $broker_cp_output_file
+rm cp_kafka_internal.yaml
+
 resolve_resources control-plane/config/100-sink cp_sink.yaml $image_prefix $tag
 cat cp_sink.yaml >> $broker_cp_output_file
 rm cp_sink.yaml


### PR DESCRIPTION
Tried these changes locally and now all conformance tests pass on release-next branch. The E2E tests still have some failures: `DONE 826 tests, 2 skipped, 23 failures in 1766.126s` A lot of the failures are related to already existing resources, similar to:
```
kafka_helper.go:243: Error while creating the topic initial-topicchange-bootstrap-server: kafkatopics.kafka.strimzi.io "initial-topicchange-bootstrap-server" already exists
```