### PR TITLE
Adding the upstream 1.2 test folder to the 1.2 from midstream

### DIFF
--- a/test/channel-e2e-tests.sh
+++ b/test/channel-e2e-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source $(dirname $0)/e2e-common.sh
+
+go_test_e2e -timeout=1h ./test/e2e_channel/... -channels=messaging.knative.dev/v1beta1:KafkaChannel || fail_test "E2E suite (KafkaChannel) failed"

--- a/test/channel-reconciler-tests.sh
+++ b/test/channel-reconciler-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source $(dirname $0)/e2e-common.sh
+
+go_test_e2e -tags=e2e,cloudevents -timeout=1h ./test/e2e_new_channel/... || fail_test "E2E (new - KafkaChannel) suite failed"

--- a/test/config/cm-watcher-broker.yaml
+++ b/test/config/cm-watcher-broker.yaml
@@ -1,0 +1,80 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-kafka-broker-cm-watcher
+  namespace: knative-eventing
+  labels:
+    app: test-kafka-broker-cm-watcher
+    kafka.eventing.knative.dev/release: devel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-kafka-broker-cm-watcher
+  template:
+    metadata:
+      name: test-kafka-broker-cm-watcher
+      labels:
+        app: test-kafka-broker-cm-watcher
+        kafka.eventing.knative.dev/release: devel
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: kafka-controller # use the same service account of our controller
+      containers:
+        - name: test-kafka-broker-cm-watcher
+          image: ko://knative.dev/eventing-kafka-broker/test/cmd/watch-cm
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: config-logging
+              mountPath: /etc/config-logging
+              readOnly: true
+          env:
+            - name: DATA_PLANE_CONFIG_MAP_NAMESPACE
+              value: knative-eventing
+            - name: DATA_PLANE_CONFIG_MAP_NAME
+              value: kafka-broker-brokers-triggers
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/eventing
+            - name: DATA_PLANE_CONFIG_FORMAT
+              value: json
+            - name: INGRESS_NAME
+              value: kafka-broker-ingress
+            - name: GENERAL_CONFIG_MAP_NAME
+              value: kafka-broker-config
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 9090
+              name: metrics
+          terminationMessagePolicy: FallbackToLogsOnError
+          terminationMessagePath: /dev/temination-log
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: config-logging
+          configMap:
+            name: config-logging
+      restartPolicy: Always

--- a/test/config/cm-watcher-sink.yaml
+++ b/test/config/cm-watcher-sink.yaml
@@ -1,0 +1,80 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-kafka-sink-cm-watcher
+  namespace: knative-eventing
+  labels:
+    app: test-kafka-sink-cm-watcher
+    kafka.eventing.knative.dev/release: devel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-kafka-sink-cm-watcher
+  template:
+    metadata:
+      name: test-kafka-sink-cm-watcher
+      labels:
+        app: test-kafka-sink-cm-watcher
+        kafka.eventing.knative.dev/release: devel
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: kafka-controller # use the same service account of our controller
+      containers:
+        - name: test-kafka-sink-cm-watcher
+          image: ko://knative.dev/eventing-kafka-broker/test/cmd/watch-cm
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: config-logging
+              mountPath: /etc/config-logging
+              readOnly: true
+          env:
+            - name: DATA_PLANE_CONFIG_MAP_NAMESPACE
+              value: knative-eventing
+            - name: DATA_PLANE_CONFIG_MAP_NAME
+              value: kafka-sink-sinks
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/eventing
+            - name: DATA_PLANE_CONFIG_FORMAT
+              value: json
+            - name: INGRESS_NAME
+              value: kafka-sink-ingress
+            - name: GENERAL_CONFIG_MAP_NAME
+              value: kafka-sink-config
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 9090
+              name: metrics
+          terminationMessagePolicy: FallbackToLogsOnError
+          terminationMessagePath: /dev/temination-log
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: config-logging
+          configMap:
+            name: config-logging
+      restartPolicy: Always

--- a/test/config/default-ch-webhook.yaml
+++ b/test/config/default-ch-webhook.yaml
@@ -1,0 +1,32 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-ch-webhook
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-eventing
+data:
+  # Configuration for defaulting channels that do not specify CRD implementations.
+  default-ch-config: |
+    clusterDefault:
+      apiVersion: messaging.knative.dev/v1beta1
+      kind: KafkaChannel
+      spec:
+        numPartitions: 10
+        replicationFactor: 3

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -1,28 +1,6 @@
 #!/usr/bin/env bash
 
-# TODO work around networking issues, see https://github.com/kubernetes/test-infra/issues/23741
-iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
-
-# variables used:
-# - SKIP_INITIALIZE (default: false) - skip cluster creation.
-# - LOCAL_DEVELOPMENT (default: false) - skip heavy workloads installation like load and chaos generators.
-
-readonly SKIP_INITIALIZE=${SKIP_INITIALIZE:-false}
-readonly LOCAL_DEVELOPMENT=${LOCAL_DEVELOPMENT:-false}
-export REPLICAS=${REPLICAS:-3}
-
-ROOT_DIR=$(dirname $0)/..
-
 source $(dirname $0)/e2e-common.sh
-
-# If gcloud is not available make it a no-op, not an error.
-which gcloud &>/dev/null || gcloud() { echo "[ignore-gcloud $*]" 1>&2; }
-
-# Use GNU tools on macOS. Requires the 'grep' and 'gnu-sed' Homebrew formulae.
-if [ "$(uname)" == "Darwin" ]; then
-  sed=gsed
-  grep=ggrep
-fi
 
 if ! ${SKIP_INITIALIZE}; then
   initialize $@ --skip-istio-addon
@@ -39,15 +17,21 @@ header "Waiting Knative eventing to come up"
 
 wait_until_pods_running knative-eventing || fail_test "Pods in knative-eventing didn't come up"
 
+export_logs_continuously
+
 header "Running tests"
 
-export_logs_continuously "kafka-broker-dispatcher" "kafka-broker-receiver" "kafka-sink-receiver"
+if [ "${EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO:-""}" != "" ]; then
+  # if this flag exists, only test Kafka channel scenarios with auth
+  $(dirname $0)/channel-e2e-tests.sh || fail_test "Failed to execute KafkaChannel tests"
+  success
+fi
 
-go_test_e2e -timeout=30m ./test/e2e_new/... || fail_test "E2E (new) suite failed"
-go_test_e2e -timeout=30m ./test/e2e/... || fail_test "E2E suite failed"
+go_test_e2e -timeout=1h ./test/e2e/... || fail_test "E2E suite failed"
+
+go_test_e2e -timeout=1h ./test/e2e_channel/... -channels=messaging.knative.dev/v1beta1:KafkaChannel || fail_test "E2E suite (KafkaChannel) failed"
 
 go_test_e2e -tags=deletecm ./test/e2e/... || fail_test "E2E (deletecm) suite failed"
-go_test_e2e -tags=deletecm ./test/e2e_new/... || fail_test "E2E (new deletecm) suite failed"
 
 if ! ${LOCAL_DEVELOPMENT}; then
   go_test_e2e -tags=sacura -timeout=40m ./test/e2e/... || fail_test "E2E (sacura) suite failed"

--- a/test/e2e/broker_redelivery_test.go
+++ b/test/e2e/broker_redelivery_test.go
@@ -29,7 +29,7 @@ import (
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/resources"
 
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	kafkatesting "knative.dev/eventing-kafka-broker/test/pkg/testing"
 )
 

--- a/test/e2e/broker_sasl_ssl_test.go
+++ b/test/e2e/broker_sasl_ssl_test.go
@@ -38,7 +38,7 @@ import (
 	"knative.dev/eventing/test/lib/sender"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	. "knative.dev/eventing-kafka-broker/test/pkg/testing"
 )
 

--- a/test/e2e/broker_trigger_sink_test.go
+++ b/test/e2e/broker_trigger_sink_test.go
@@ -34,7 +34,7 @@ import (
 
 	eventingv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
 	eventingv1alpha1clientset "knative.dev/eventing-kafka-broker/control-plane/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	"knative.dev/eventing-kafka-broker/test/pkg/addressable"
 	"knative.dev/eventing-kafka-broker/test/pkg/sink"
 	testingpkg "knative.dev/eventing-kafka-broker/test/pkg/testing"
@@ -50,7 +50,6 @@ import (
                 +--------+
 */
 func TestBrokerV1TriggersV1SinkV1Alpha1(t *testing.T) {
-	t.Skip("for now...")
 	testingpkg.RunMultipleN(t, 10, func(t *testing.T) {
 
 		ctx := context.Background()

--- a/test/e2e/broker_trigger_test.go
+++ b/test/e2e/broker_trigger_test.go
@@ -34,8 +34,8 @@ import (
 	"knative.dev/eventing/test/lib/resources"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/broker"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
 	kafkatest "knative.dev/eventing-kafka-broker/test/pkg/kafka"
 	testingpkg "knative.dev/eventing-kafka-broker/test/pkg/testing"
 )

--- a/test/e2e/conformance/control_plane_conformance_test.go
+++ b/test/e2e/conformance/control_plane_conformance_test.go
@@ -26,7 +26,7 @@ import (
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/resources"
 
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	pkgtesting "knative.dev/eventing-kafka-broker/test/pkg/testing"
 )
 

--- a/test/e2e/conformance/data_plane_conformance_test.go
+++ b/test/e2e/conformance/data_plane_conformance_test.go
@@ -34,7 +34,7 @@ import (
 	"knative.dev/eventing/test/lib/sender"
 	pkgtest "knative.dev/pkg/test"
 
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	pkgtesting "knative.dev/eventing-kafka-broker/test/pkg/testing"
 )
 

--- a/test/e2e/conformance/main_test.go
+++ b/test/e2e/conformance/main_test.go
@@ -20,22 +20,24 @@
 package conformance
 
 import (
+	"log"
 	"os"
 	"testing"
 
 	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/test/zipkin"
 )
 
-const (
-	SystemNamespace = "knative-eventing"
-	LogsDir         = "knative-eventing-logs"
-)
+func TestMain(m *testing.M) {
 
-func TestMain(t *testing.M) {
+	os.Exit(func() int {
+		// Any tests may SetupZipkinTracing, it will only actually be done once. This should be the ONLY
+		// place that cleans it up. If an individual test calls this instead, then it will break other
+		// tests that need the tracing in place.
+		defer zipkin.CleanupZipkinTracingSetup(log.Printf)
+		defer testlib.ExportLogs(testlib.SystemLogsDir, system.Namespace())
 
-	exit := t.Run()
-
-	testlib.ExportLogs(LogsDir, SystemNamespace)
-
-	os.Exit(exit)
+		return m.Run()
+	}())
 }

--- a/test/e2e/kafka_sink.go
+++ b/test/e2e/kafka_sink.go
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	testlib "knative.dev/eventing/test/lib"
+
+	eventingv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	eventingv1alpha1clientset "knative.dev/eventing-kafka-broker/control-plane/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/test/pkg/addressable"
+	"knative.dev/eventing-kafka-broker/test/pkg/sink"
+
+	. "knative.dev/eventing-kafka-broker/test/pkg/testing"
+)
+
+const (
+	sinkSecretName = "secret-test"
+)
+
+func RunTestKafkaSink(t *testing.T, mode string, sp SecretProvider, opts ...func(kss *eventingv1alpha1.KafkaSinkSpec) error) {
+	RunMultiple(t, func(t *testing.T) {
+
+		ctx := context.Background()
+
+		const (
+			kafkaSinkName = "kafka-sink"
+		)
+
+		client := testlib.Setup(t, false)
+		defer testlib.TearDown(client)
+
+		clientSet, err := eventingv1alpha1clientset.NewForConfig(client.Config)
+		require.Nil(t, err)
+
+		// Create a KafkaSink with the following spec.
+
+		kss := eventingv1alpha1.KafkaSinkSpec{
+			Topic:             "kafka-sink-" + client.Namespace,
+			NumPartitions:     pointer.Int32Ptr(10),
+			ReplicationFactor: func(rf int16) *int16 { return &rf }(1),
+			BootstrapServers:  BootstrapServersPlaintextArr,
+			ContentMode:       pointer.StringPtr(mode),
+		}
+		for _, opt := range opts {
+			require.Nil(t, opt(&kss))
+		}
+
+		t.Logf("%+v", kss)
+
+		if sp != nil {
+			secretData := sp(t, client)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: client.Namespace,
+					Name:      sinkSecretName,
+				},
+				Data: secretData,
+			}
+			secret, err = client.Kube.CoreV1().Secrets(client.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+			require.Nil(t, err)
+			client.Tracker.Add(corev1.GroupName, "v1", "Secret", secret.Namespace, secret.Name)
+		}
+
+		createFunc := sink.CreatorV1Alpha1(clientSet, kss)
+
+		kafkaSink, err := createFunc(types.NamespacedName{
+			Namespace: client.Namespace,
+			Name:      kafkaSinkName,
+		})
+		require.Nil(t, err)
+
+		ks, err := clientSet.KafkaSinks(client.Namespace).Get(ctx, kafkaSinkName, metav1.GetOptions{})
+		require.Nil(t, err)
+		client.Tracker.AddObj(ks)
+
+		client.WaitForResourceReadyOrFail(kafkaSink.Name, &kafkaSink.TypeMeta)
+
+		// Send events to the KafkaSink.
+		ids := addressable.Send(t, kafkaSink)
+
+		// Read events from the topic.
+		sink.Verify(t, client, mode, kss.Topic, ids)
+	})
+}

--- a/test/e2e/kafka_sink_test.go
+++ b/test/e2e/kafka_sink_test.go
@@ -20,129 +20,43 @@
 package e2e
 
 import (
-	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
-	testlib "knative.dev/eventing/test/lib"
 
 	eventingv1alpha1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
-	eventingv1alpha1clientset "knative.dev/eventing-kafka-broker/control-plane/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
-	"knative.dev/eventing-kafka-broker/test/pkg/addressable"
-	"knative.dev/eventing-kafka-broker/test/pkg/sink"
 	. "knative.dev/eventing-kafka-broker/test/pkg/testing"
 )
 
-const (
-	sinkSecretName = "secret-test"
-)
-
 func TestKafkaSinkV1Alpha1DefaultContentMode(t *testing.T) {
-	t.Skip("for now")
-	testKafkaSink(t, eventingv1alpha1.ModeStructured, nil, func(kss *eventingv1alpha1.KafkaSinkSpec) error {
+	RunTestKafkaSink(t, eventingv1alpha1.ModeStructured, nil, func(kss *eventingv1alpha1.KafkaSinkSpec) error {
 		kss.ContentMode = pointer.StringPtr("")
 		return nil
 	})
 }
 
 func TestKafkaSinkV1Alpha1StructuredContentMode(t *testing.T) {
-	t.Skip("for now")
-	testKafkaSink(t, eventingv1alpha1.ModeStructured, nil)
+	RunTestKafkaSink(t, eventingv1alpha1.ModeStructured, nil)
 }
 
 func TestKafkaSinkV1Alpha1BinaryContentMode(t *testing.T) {
-	t.Skip("for now")
-	testKafkaSink(t, eventingv1alpha1.ModeBinary, nil)
+	RunTestKafkaSink(t, eventingv1alpha1.ModeBinary, nil)
 }
 
 func TestKafkaSinkV1Alpha1AuthPlaintext(t *testing.T) {
-	t.Skip("for now")
-	testKafkaSink(t, eventingv1alpha1.ModeStructured, Plaintext, withBootstrap(BootstrapServersPlaintextArr), withSecret)
+	RunTestKafkaSink(t, eventingv1alpha1.ModeStructured, Plaintext, withBootstrap(BootstrapServersPlaintextArr), withSecret)
 }
 
 func TestKafkaSinkV1Alpha1AuthSsl(t *testing.T) {
-	t.Skip("for now")
-	testKafkaSink(t, eventingv1alpha1.ModeStructured, Ssl, withBootstrap(BootstrapServersSslArr), withSecret)
+	RunTestKafkaSink(t, eventingv1alpha1.ModeStructured, Ssl, withBootstrap(BootstrapServersSslArr), withSecret)
 }
 
 func TestKafkaSinkV1Alpha1AuthSaslPlaintextScram512(t *testing.T) {
-	t.Skip("for now")
-	testKafkaSink(t, eventingv1alpha1.ModeStructured, SaslPlaintextScram512, withBootstrap(BootstrapServersSaslPlaintextArr), withSecret)
+	RunTestKafkaSink(t, eventingv1alpha1.ModeStructured, SaslPlaintextScram512, withBootstrap(BootstrapServersSaslPlaintextArr), withSecret)
 }
 
 func TestKafkaSinkV1Alpha1AuthSslSaslScram512(t *testing.T) {
-	t.Skip("for now")
-	testKafkaSink(t, eventingv1alpha1.ModeStructured, SslSaslScram512, withBootstrap(BootstrapServersSslSaslScramArr), withSecret)
-}
-
-func testKafkaSink(t *testing.T, mode string, sp SecretProvider, opts ...func(kss *eventingv1alpha1.KafkaSinkSpec) error) {
-	RunMultiple(t, func(t *testing.T) {
-
-		ctx := context.Background()
-
-		const (
-			kafkaSinkName = "kafka-sink"
-		)
-
-		client := testlib.Setup(t, false)
-		defer testlib.TearDown(client)
-
-		clientSet, err := eventingv1alpha1clientset.NewForConfig(client.Config)
-		require.Nil(t, err)
-
-		// Create a KafkaSink with the following spec.
-
-		kss := eventingv1alpha1.KafkaSinkSpec{
-			Topic:             "kafka-sink-" + client.Namespace,
-			NumPartitions:     pointer.Int32Ptr(10),
-			ReplicationFactor: func(rf int16) *int16 { return &rf }(1),
-			BootstrapServers:  BootstrapServersPlaintextArr,
-			ContentMode:       pointer.StringPtr(mode),
-		}
-		for _, opt := range opts {
-			require.Nil(t, opt(&kss))
-		}
-
-		t.Log(kss)
-
-		if sp != nil {
-			secretData := sp(t, client)
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: client.Namespace,
-					Name:      sinkSecretName,
-				},
-				Data: secretData,
-			}
-			secret, err = client.Kube.CoreV1().Secrets(client.Namespace).Create(ctx, secret, metav1.CreateOptions{})
-			require.Nil(t, err)
-			client.Tracker.Add(corev1.GroupName, "v1", "Secret", secret.Namespace, secret.Name)
-		}
-
-		createFunc := sink.CreatorV1Alpha1(clientSet, kss)
-
-		kafkaSink, err := createFunc(types.NamespacedName{
-			Namespace: client.Namespace,
-			Name:      kafkaSinkName,
-		})
-		require.Nil(t, err)
-
-		ks, err := clientSet.KafkaSinks(client.Namespace).Get(ctx, kafkaSinkName, metav1.GetOptions{})
-		require.Nil(t, err)
-		client.Tracker.AddObj(ks)
-
-		client.WaitForResourceReadyOrFail(kafkaSink.Name, &kafkaSink.TypeMeta)
-
-		// Send events to the KafkaSink.
-		ids := addressable.Send(t, kafkaSink)
-
-		// Read events from the topic.
-		sink.Verify(t, client, mode, kss.Topic, ids)
-	})
+	RunTestKafkaSink(t, eventingv1alpha1.ModeStructured, SslSaslScram512, withBootstrap(BootstrapServersSslSaslScramArr), withSecret)
 }
 
 func withSecret(kss *eventingv1alpha1.KafkaSinkSpec) error {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -24,18 +24,13 @@ import (
 	"testing"
 
 	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/pkg/system"
 )
 
-const (
-	SystemNamespace = "knative-eventing"
-	LogsDir         = "knative-eventing-logs"
-)
+func TestMain(m *testing.M) {
+	os.Exit(func() int {
+		defer testlib.ExportLogs(testlib.SystemLogsDir, system.Namespace())
 
-func TestMain(t *testing.M) {
-
-	exit := t.Run()
-
-	testlib.ExportLogs(LogsDir, SystemNamespace)
-
-	os.Exit(exit)
+		return m.Run()
+	}())
 }

--- a/test/e2e/sacura_test.go
+++ b/test/e2e/sacura_test.go
@@ -50,7 +50,6 @@ const (
 )
 
 func TestSacuraJob(t *testing.T) {
-	t.Skip("for now")
 
 	c := testlib.Setup(t, false)
 	defer testlib.TearDown(c)

--- a/test/e2e_channel/channel_event_transformation_test.go
+++ b/test/e2e_channel/channel_event_transformation_test.go
@@ -1,0 +1,31 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2022 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e_channel
+
+import (
+	"context"
+	"testing"
+
+	"knative.dev/eventing/test/e2e/helpers"
+)
+
+func TestEventTransformationForSubscription(t *testing.T) {
+	helpers.EventTransformationForSubscriptionTestHelper(context.Background(), t, helpers.SubscriptionV1, channelTestRunner)
+}

--- a/test/e2e_channel/channel_single_event_test.go
+++ b/test/e2e_channel/channel_single_event_test.go
@@ -1,0 +1,36 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e_channel
+
+import (
+	"context"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"knative.dev/eventing/test/e2e/helpers"
+)
+
+func TestSingleBinaryEventForChannel(t *testing.T) {
+	helpers.SingleEventForChannelTestHelper(context.Background(), t, cloudevents.EncodingBinary, helpers.SubscriptionV1, "", channelTestRunner)
+}
+
+func TestSingleStructuredEventForChannel(t *testing.T) {
+	helpers.SingleEventForChannelTestHelper(context.Background(), t, cloudevents.EncodingStructured, helpers.SubscriptionV1, "", channelTestRunner)
+}

--- a/test/e2e_channel/conformance/channel_addressable_resolver_cluster_role_test.go
+++ b/test/e2e_channel/conformance/channel_addressable_resolver_cluster_role_test.go
@@ -1,0 +1,31 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package conformance
+
+import (
+	"testing"
+
+	eventingconformancehelpers "knative.dev/eventing/test/conformance/helpers"
+	testlib "knative.dev/eventing/test/lib"
+)
+
+func TestChannelAddressableResolverClusterRoleTest(t *testing.T) {
+	eventingconformancehelpers.TestChannelAddressableResolverClusterRoleTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
+}

--- a/test/e2e_channel/conformance/channel_channelable_manipulator_cluster_role_test.go
+++ b/test/e2e_channel/conformance/channel_channelable_manipulator_cluster_role_test.go
@@ -1,0 +1,32 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package conformance
+
+import (
+	"context"
+	"testing"
+
+	eventingconformancehelpers "knative.dev/eventing/test/conformance/helpers"
+	testlib "knative.dev/eventing/test/lib"
+)
+
+func TestChannelChannelableManipulatorClusterRoleTest(t *testing.T) {
+	eventingconformancehelpers.TestChannelChannelableManipulatorClusterRoleTestRunner(context.Background(), t, channelTestRunner, testlib.SetupClientOptionNoop)
+}

--- a/test/e2e_channel/conformance/channel_crd_metadata_test.go
+++ b/test/e2e_channel/conformance/channel_crd_metadata_test.go
@@ -1,0 +1,31 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package conformance
+
+import (
+	"testing"
+
+	eventingconformancehelpers "knative.dev/eventing/test/conformance/helpers"
+	testlib "knative.dev/eventing/test/lib"
+)
+
+func TestChannelCRDMetadata(t *testing.T) {
+	eventingconformancehelpers.ChannelCRDMetadataTestHelperWithChannelTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
+}

--- a/test/e2e_channel/conformance/channel_crd_name_test.go
+++ b/test/e2e_channel/conformance/channel_crd_name_test.go
@@ -1,0 +1,31 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package conformance
+
+import (
+	"testing"
+
+	eventingconformancehelpers "knative.dev/eventing/test/conformance/helpers"
+	testlib "knative.dev/eventing/test/lib"
+)
+
+func TestChannelCRDName(t *testing.T) {
+	eventingconformancehelpers.ChannelCRDNameTestHelperWithChannelTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
+}

--- a/test/e2e_channel/conformance/channel_spec_test.go
+++ b/test/e2e_channel/conformance/channel_spec_test.go
@@ -1,0 +1,31 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package conformance
+
+import (
+	"testing"
+
+	eventingconformancehelpers "knative.dev/eventing/test/conformance/helpers"
+	testlib "knative.dev/eventing/test/lib"
+)
+
+func TestChannelSpec(t *testing.T) {
+	eventingconformancehelpers.ChannelSpecTestHelperWithChannelTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
+}

--- a/test/e2e_channel/conformance/channel_status_subscriber_test.go
+++ b/test/e2e_channel/conformance/channel_status_subscriber_test.go
@@ -1,0 +1,32 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package conformance
+
+import (
+	"context"
+	"testing"
+
+	eventingconformancehelpers "knative.dev/eventing/test/conformance/helpers"
+	testlib "knative.dev/eventing/test/lib"
+)
+
+func TestChannelStatusSubscriber(t *testing.T) {
+	eventingconformancehelpers.ChannelStatusSubscriberTestHelperWithChannelTestRunner(context.Background(), t, channelTestRunner, testlib.SetupClientOptionNoop)
+}

--- a/test/e2e_channel/conformance/channel_status_test.go
+++ b/test/e2e_channel/conformance/channel_status_test.go
@@ -1,0 +1,31 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package conformance
+
+import (
+	"testing"
+
+	eventingconformancehelpers "knative.dev/eventing/test/conformance/helpers"
+	testlib "knative.dev/eventing/test/lib"
+)
+
+func TestChannelStatus(t *testing.T) {
+	eventingconformancehelpers.ChannelStatusTestHelperWithChannelTestRunner(t, channelTestRunner, testlib.SetupClientOptionNoop)
+}

--- a/test/e2e_channel/conformance/channel_tracing_test.go
+++ b/test/e2e_channel/conformance/channel_tracing_test.go
@@ -1,0 +1,59 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package conformance
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing/test/conformance/helpers"
+	testlib "knative.dev/eventing/test/lib"
+
+	contribtest "knative.dev/eventing-kafka/test"
+)
+
+// Eventing channels are v1, but Kafka channel is v1beta1.
+const kafkaChannelAPIVersion = "messaging.knative.dev/v1beta1"
+
+func TestChannelTracingWithReply(t *testing.T) {
+	// TODO: skip for now
+	t.Skip()
+
+	// Enable this test only for Kafka
+	helpers.ChannelTracingTestHelperWithChannelTestRunner(context.Background(), t, testlib.ComponentsTestRunner{
+		ComponentFeatureMap: map[metav1.TypeMeta][]testlib.Feature{
+			{
+				APIVersion: kafkaChannelAPIVersion,
+				Kind:       contribtest.KafkaChannelKind,
+			}: {
+				testlib.FeatureBasic,
+				testlib.FeatureRedelivery,
+				testlib.FeaturePersistence,
+			},
+		},
+		ComponentsToTest: []metav1.TypeMeta{
+			{
+				APIVersion: kafkaChannelAPIVersion,
+				Kind:       contribtest.KafkaChannelKind,
+			},
+		},
+	}, testlib.SetupClientOptionNoop)
+}

--- a/test/e2e_channel/conformance/main_test.go
+++ b/test/e2e_channel/conformance/main_test.go
@@ -1,0 +1,53 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package conformance
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"knative.dev/eventing-kafka/test"
+	eventingTest "knative.dev/eventing/test"
+	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/test/zipkin"
+)
+
+var channelTestRunner testlib.ComponentsTestRunner
+
+func TestMain(m *testing.M) {
+
+	os.Exit(func() int {
+		eventingTest.InitializeEventingFlags()
+		channelTestRunner = testlib.ComponentsTestRunner{
+			ComponentFeatureMap: test.ChannelFeatureMap,
+			ComponentsToTest:    eventingTest.EventingFlags.Channels,
+		}
+
+		// Any tests may SetupZipkinTracing, it will only actually be done once. This should be the ONLY
+		// place that cleans it up. If an individual test calls this instead, then it will break other
+		// tests that need the tracing in place.
+		defer zipkin.CleanupZipkinTracingSetup(log.Printf)
+		defer testlib.ExportLogs(testlib.SystemLogsDir, system.Namespace())
+
+		return m.Run()
+	}())
+}

--- a/test/e2e_channel/main_test.go
+++ b/test/e2e_channel/main_test.go
@@ -1,0 +1,46 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e_channel
+
+import (
+	"os"
+	"testing"
+
+	"knative.dev/eventing-kafka/test"
+	eventingTest "knative.dev/eventing/test"
+	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/pkg/system"
+)
+
+var channelTestRunner testlib.ComponentsTestRunner
+
+func TestMain(m *testing.M) {
+
+	eventingTest.InitializeEventingFlags()
+	channelTestRunner = testlib.ComponentsTestRunner{
+		ComponentFeatureMap: test.ChannelFeatureMap,
+		ComponentsToTest:    eventingTest.EventingFlags.Channels,
+	}
+	os.Exit(func() int {
+		defer testlib.ExportLogs(testlib.SystemLogsDir, system.Namespace())
+
+		return m.Run()
+	}())
+}

--- a/test/e2e_new/broker_conformance_test.go
+++ b/test/e2e_new/broker_conformance_test.go
@@ -34,7 +34,7 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 )
 
 func TestBrokerConformance(t *testing.T) {

--- a/test/e2e_new/broker_delete_config_map_test.go
+++ b/test/e2e_new/broker_delete_config_map_test.go
@@ -23,8 +23,6 @@ import (
 	"testing"
 
 	. "github.com/cloudevents/sdk-go/v2/test"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
-	"knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap"
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/trigger"
 	"knative.dev/pkg/system"
@@ -35,6 +33,9 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 	"knative.dev/reconciler-test/resources/svc"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
+	"knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap"
 )
 
 func TestBrokerDeleteContractConfigMap(t *testing.T) {

--- a/test/e2e_new/broker_not_ready_test.go
+++ b/test/e2e_new/broker_not_ready_test.go
@@ -22,14 +22,15 @@ package e2e_new
 import (
 	"testing"
 
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
-	brokerconfigmap "knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap/broker"
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/pkg/system"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
+	brokerconfigmap "knative.dev/eventing-kafka-broker/test/e2e_new/resources/configmap/broker"
 )
 
 func TestBrokerNotReadyAfterBeingReady(t *testing.T) {

--- a/test/e2e_new/main_test.go
+++ b/test/e2e_new/main_test.go
@@ -33,7 +33,7 @@ import (
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/reconciler-test/pkg/environment"
 
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 )
 
 // global is the singleton instance of GlobalEnvironment. It is used to parse

--- a/test/e2e_new/ordered_test.go
+++ b/test/e2e_new/ordered_test.go
@@ -31,9 +31,6 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 	"github.com/stretchr/testify/require"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
-	"knative.dev/eventing-kafka-broker/test/e2e_new/multiple_partition_config"
-	"knative.dev/eventing-kafka-broker/test/e2e_new/single_partition_config"
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/trigger"
 	"knative.dev/pkg/system"
@@ -42,6 +39,10 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 	"knative.dev/reconciler-test/resources/svc"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
+	"knative.dev/eventing-kafka-broker/test/e2e_new/multiple_partition_config"
+	"knative.dev/eventing-kafka-broker/test/e2e_new/single_partition_config"
 
 	. "knative.dev/reconciler-test/pkg/eventshub/assert"
 )

--- a/test/e2e_new/run.go
+++ b/test/e2e_new/run.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e_new
+
+import (
+	"fmt"
+	"testing"
+)
+
+const (
+	// Number of times to run a test function.
+	rerunTimes = 5
+)
+
+// RunMultiple run test function f `rerunTimes` times.
+func RunMultiple(t *testing.T, f func(t *testing.T)) {
+	RunMultipleN(t, rerunTimes, f)
+}
+
+// RunMultipleN run test function f n times.
+func RunMultipleN(t *testing.T, n int, f func(t *testing.T)) {
+	t.Parallel()
+
+	if testing.Short() {
+		n = 1
+	}
+
+	for i := 0; i < n; i++ {
+		t.Run(fmt.Sprintf("%d", i), f)
+	}
+}

--- a/test/e2e_new/tracing_test.go
+++ b/test/e2e_new/tracing_test.go
@@ -35,9 +35,9 @@ import (
 	"knative.dev/reconciler-test/pkg/knative"
 	"knative.dev/reconciler-test/resources/svc"
 
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
-
 	. "knative.dev/reconciler-test/pkg/eventshub/assert"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 )
 
 func TestTracingHeaders(t *testing.T) {

--- a/test/e2e_new/trigger_finalizer_test.go
+++ b/test/e2e_new/trigger_finalizer_test.go
@@ -24,10 +24,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/reconciler-test/pkg/environment"
 
-	"github.com/stretchr/testify/assert"
-	triggerreconciler "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/trigger"
 	triggerfeatures "knative.dev/eventing/test/rekt/features/trigger"
 	"knative.dev/eventing/test/rekt/resources/trigger"
 	"knative.dev/pkg/system"
@@ -36,56 +36,72 @@ import (
 	"knative.dev/reconciler-test/pkg/k8s"
 	"knative.dev/reconciler-test/pkg/knative"
 	"knative.dev/reconciler-test/resources/svc"
+
+	triggerreconciler "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/trigger"
 )
 
-func TestTriggerNoFinalizerOnBrokerNotFound(t *testing.T) {
+func TestTriggerNoFinalizer(t *testing.T) {
+	RunMultiple(t, func(t *testing.T) {
+		ctx, env := global.Environment(
+			knative.WithKnativeNamespace(system.Namespace()),
+			knative.WithLoggingConfig,
+			knative.WithTracingConfig,
+			k8s.WithEventListener,
+			environment.Managed(t),
+		)
 
-	t.Skip("Flaky https://github.com/knative-sandbox/eventing-kafka-broker/issues/885")
-	t.Parallel()
+		t.Logf("Namespace is %s", env.Namespace())
 
-	ctx, env := global.Environment(
-		knative.WithKnativeNamespace(system.Namespace()),
-		knative.WithLoggingConfig,
-		knative.WithTracingConfig,
-		k8s.WithEventListener,
-		environment.Managed(t),
-	)
-
-	t.Logf("Namespace is %s", env.Namespace())
-
-	env.Test(ctx, t, triggerNoFinalizerOnBrokerNotFound())
+		env.Test(ctx, t, triggerNoFinalizerOnBrokerNotFound())
+		env.Test(ctx, t, unknownBrokerClass("Unknown"))
+		env.Test(ctx, t, unknownBrokerClass("MTChannelBasedBroker"))
+	})
 }
 
-//nolint:golint,unused
 func triggerNoFinalizerOnBrokerNotFound() *feature.Feature {
 
 	f := feature.NewFeature()
 
-	const responseWaitTime = 100 * time.Millisecond
-
+	brokerName := feature.MakeRandomK8sName("broker")
 	triggerName := feature.MakeRandomK8sName("trigger")
 	sinkName := feature.MakeRandomK8sName("sink")
 
-	f.Setup("install sink", eventshub.Install(
-		sinkName,
-		eventshub.StartReceiver,
-		eventshub.ResponseWaitTime(responseWaitTime),
-	))
-
-	f.Setup("install trigger", trigger.Install(
-		triggerName,
-		"broker",
+	f.Setup("install sink", eventshub.Install(sinkName, eventshub.StartReceiver))
+	f.Setup("install trigger", trigger.Install(triggerName, brokerName,
 		trigger.WithSubscriber(svc.AsKReference(sinkName), ""),
 	))
-
 	f.Setup("set trigger name", triggerfeatures.SetTriggerName(triggerName))
 
-	f.Assert("eventually trigger has no finalizer", func(ctx context.Context, t feature.T) {
-		time.Sleep(time.Second * 20) // "eventually"
-		for _, f := range triggerfeatures.GetTrigger(ctx, t).Finalizers {
-			assert.NotEqual(t, f, triggerreconciler.FinalizerName)
-		}
-	})
+	f.Assert("eventually trigger has no finalizer", hasNoKafkaBrokerFinalizer())
 
 	return f
+}
+
+func unknownBrokerClass(brokerClass string) *feature.Feature {
+	f := feature.NewFeatureNamed("Unknown Broker Class - " + brokerClass)
+
+	brokerName := feature.MakeRandomK8sName("broker")
+	triggerName := feature.MakeRandomK8sName("trigger")
+	sink := feature.MakeRandomK8sName("sink")
+
+	f.Setup("Install Broker", broker.Install(brokerName, broker.WithBrokerClass(brokerClass)))
+	f.Setup("Install events hub", eventshub.Install(sink, eventshub.StartReceiver))
+	f.Setup("Install Trigger", trigger.Install(triggerName, brokerName,
+		trigger.WithSubscriber(svc.AsKReference(sink), ""),
+	))
+	f.Setup("set trigger name", triggerfeatures.SetTriggerName(triggerName))
+
+	f.Assert("eventually trigger has no finalizer", hasNoKafkaBrokerFinalizer())
+
+	return f
+}
+
+func hasNoKafkaBrokerFinalizer() func(ctx context.Context, t feature.T) {
+	return func(ctx context.Context, t feature.T) {
+		time.Sleep(time.Second * 20) // "eventually"
+		tr := triggerfeatures.GetTrigger(ctx, t)
+		for _, f := range tr.Finalizers {
+			require.NotEqual(t, f, triggerreconciler.FinalizerName, "%+v", tr)
+		}
+	}
 }

--- a/test/e2e_new_channel/kafka_channel_test.go
+++ b/test/e2e_new_channel/kafka_channel_test.go
@@ -1,0 +1,106 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e_new_channel
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"knative.dev/eventing-kafka/pkg/channel/distributed/common/kafka/constants"
+
+	"knative.dev/pkg/system"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/knative"
+	"knative.dev/reconciler-test/pkg/state"
+
+	"knative.dev/eventing-kafka/test/rekt/features/kafkachannel"
+)
+
+const kafkaChannelTestPrefix = "kc-rekt-test-"
+
+func TestKafkaChannelReadiness(t *testing.T) {
+
+	// Run Test In Parallel With Others
+	t.Parallel()
+
+	// Create The Test Context / Environment
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.WithPollTimings(3*time.Second, 120*time.Second),
+		environment.Managed(t),
+	)
+
+	// Generate Unique Test Names And Add To Context Store
+	ctx = state.ContextWith(ctx, &state.KVStore{})
+	testName := feature.MakeRandomK8sName(kafkaChannelTestPrefix)
+	state.SetOrFail(ctx, t, kafkachannel.TestNameKey, testName)
+	state.SetOrFail(ctx, t, kafkachannel.ReceiverNameKey, testName+"-receiver")
+
+	// Define The Features To Test
+	testFeatures := []*feature.Feature{
+		kafkachannel.UnsubscribedKafkaChannelReadiness(ctx, t),
+		kafkachannel.SubscribedKafkaChannelReadiness(ctx, t),
+	}
+
+	// Test The Features
+	for _, f := range testFeatures {
+		env.Test(ctx, t, f)
+	}
+}
+
+func TestKafkaChannelEvents(t *testing.T) {
+	t.Skip()
+
+	// Run Test In Parallel With Others
+	t.Parallel()
+
+	// Create The Test Context / Environment
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.WithPollTimings(4*time.Second, 120*time.Second),
+		environment.Managed(t),
+	)
+
+	// Generate Unique Test Names And Add To Context Store
+	ctx = state.ContextWith(ctx, &state.KVStore{})
+	testName := feature.MakeRandomK8sName(kafkaChannelTestPrefix)
+	kafkaChannelServiceName := fmt.Sprintf("%s-%s", testName, constants.KafkaChannelServiceNameSuffix)
+	state.SetOrFail(ctx, t, kafkachannel.TestNameKey, testName)
+	state.SetOrFail(ctx, t, kafkachannel.SenderNameKey, testName+"-sender")
+	state.SetOrFail(ctx, t, kafkachannel.SenderSinkKey, kafkaChannelServiceName)
+	state.SetOrFail(ctx, t, kafkachannel.ReceiverNameKey, testName+"-receiver")
+
+	// Determine Time Prior To Test To Replay From
+	offsetTime := time.Now().Add(-1 * time.Minute).Format(time.RFC3339)
+
+	// Configure DataPlane, Send Events, Replay Events
+	env.Test(ctx, t, kafkachannel.ConfigureDataPlane(ctx, t))
+	env.Test(ctx, t, kafkachannel.SendEvents(ctx, t, 10, 1, 10))               // 10 Events with IDs 1-10
+	env.Test(ctx, t, kafkachannel.ReplayEvents(ctx, t, offsetTime, 20, 1, 10)) // 20 Events with IDs 1-10
+}

--- a/test/e2e_new_channel/kafka_channel_upstream_test.go
+++ b/test/e2e_new_channel/kafka_channel_upstream_test.go
@@ -1,0 +1,330 @@
+//go:build e2e && cloudevents
+// +build e2e,cloudevents
+
+/*
+ * Copyright 2022 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e_new_channel
+
+import (
+	"testing"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/reconciler-test/pkg/manifest"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"knative.dev/eventing/test/rekt/features/channel"
+	ch "knative.dev/eventing/test/rekt/resources/channel"
+	chimpl "knative.dev/eventing/test/rekt/resources/channel_impl"
+	"knative.dev/eventing/test/rekt/resources/subscription"
+	"knative.dev/pkg/system"
+	_ "knative.dev/pkg/system/testing"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/knative"
+
+	// needed for vendoring the test resource files
+	_ "knative.dev/eventing/test/rekt/resources/eventlibrary/events"
+)
+
+// TestChannelConformance
+func TestChannelConformance(t *testing.T) {
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	channelName := "mychannelimpl"
+
+	// Install and wait for a Ready Channel.
+	env.Prerequisite(ctx, t, channel.ImplGoesReady(channelName))
+
+	env.TestSet(ctx, t, channel.ControlPlaneConformance(channelName))
+	env.TestSet(ctx, t, channel.DataPlaneConformance(channelName))
+}
+
+// TestSmoke_Channel
+func TestSmoke_Channel(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment()
+	t.Cleanup(env.Finish)
+
+	names := []string{
+		"customname",
+		"name-with-dash",
+		"name1with2numbers3",
+		"name63-01234567890123456789012345678901234567890123456789012345",
+	}
+
+	for _, name := range names {
+		env.Test(ctx, t, channel.GoesReady(name))
+	}
+}
+
+// TestSmoke_ChannelImpl
+func TestSmoke_ChannelImpl(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment()
+	t.Cleanup(env.Finish)
+
+	names := []string{
+		"customname",
+		"name-with-dash",
+		"name1with2numbers3",
+		"name63-01234567890123456789012345678901234567890123456789012345",
+	}
+
+	for _, name := range names {
+		env.Test(ctx, t, channel.ImplGoesReady(name))
+	}
+
+}
+
+// TestSmoke_ChannelWithSubscription
+func TestSmoke_ChannelWithSubscription(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment()
+	t.Cleanup(env.Finish)
+
+	channelName := "mychannel"
+
+	// Install and wait for a Ready Channel.
+	env.Prerequisite(ctx, t, channel.GoesReady(channelName))
+	chRef := ch.AsRef(channelName)
+
+	names := []string{
+		"customname",
+		"name-with-dash",
+		"name1with2numbers3",
+		"name63-01234567890123456789012345678901234567890123456789012345",
+	}
+
+	for _, name := range names {
+		env.Test(ctx, t, channel.SubscriptionGoesReady(name,
+			subscription.WithChannel(chRef),
+			subscription.WithSubscriber(nil, "http://example.com")),
+		)
+	}
+}
+
+// TestSmoke_ChannelImplWithSubscription
+func TestSmoke_ChannelImplWithSubscription(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment()
+	t.Cleanup(env.Finish)
+
+	channelName := "mychannelimpl"
+
+	// Install and wait for a Ready Channel.
+	env.Prerequisite(ctx, t, channel.ImplGoesReady(channelName))
+	chRef := chimpl.AsRef(channelName)
+
+	names := []string{
+		"customname",
+		"name-with-dash",
+		"name1with2numbers3",
+		"name63-01234567890123456789012345678901234567890123456789012345",
+	}
+
+	for _, name := range names {
+		env.Test(ctx, t, channel.SubscriptionGoesReady(name,
+			subscription.WithChannel(chRef),
+			subscription.WithSubscriber(nil, "http://example.com")),
+		)
+	}
+}
+
+/*
+TestChannelChainByUsingReplyAsSubscriber tests the following scenario:
+
+EventSource ---> (Channel ---> Subscription) x 10 ---> Sink
+
+It uses Subscription's spec.reply as spec.subscriber.
+
+This test should fail with https://github.com/knative/eventing/issues/5756 done.
+
+*/
+func TestChannelChainByUsingReplyAsSubscriber(t *testing.T) {
+	// This test fails with our KafkaChannel here since the test assumes it is ok to leave Subscription's `spec.subscriber` empty.
+	// Leaving that empty is not handled in the data channel as there won't be any `egress.Destination` in the contract resource.
+	// Dataplane won't know what to do when the destination is empty.
+	// See https://github.com/knative/eventing/issues/5756#issuecomment-1012996766
+	t.Skip("We don't allow nil `spec.subscriber` in Subscription. See https://github.com/knative/eventing/issues/5756#issuecomment-1012996766")
+
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	createSubscriberFn := func(ref *duckv1.KReference, uri string) manifest.CfgFn {
+		return subscription.WithReply(ref, uri)
+	}
+	env.Test(ctx, t, channel.ChannelChain(10, createSubscriberFn))
+}
+
+/*
+TestChannelChain tests the following scenario:
+
+EventSource ---> (Channel ---> Subscription) x 10 ---> Sink
+
+*/
+func TestChannelChain(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	createSubscriberFn := func(ref *duckv1.KReference, uri string) manifest.CfgFn {
+		return subscription.WithSubscriber(ref, uri)
+	}
+	env.Test(ctx, t, channel.ChannelChain(10, createSubscriberFn))
+}
+
+/*
+TestChannelDeadLetterSink tests if the events that cannot be delivered end up in
+the dead letter sink.
+
+It uses Subscription's spec.reply as spec.subscriber.
+*/
+func TestChannelDeadLetterSink(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	createSubscriberFn := func(ref *duckv1.KReference, uri string) manifest.CfgFn {
+		return subscription.WithSubscriber(ref, uri)
+	}
+	env.Test(ctx, t, channel.DeadLetterSink(createSubscriberFn))
+}
+
+/*
+TestChannelDeadLetterSinkByUsingReplyAsSubscriber tests if the events that cannot be delivered end up in
+the dead letter sink.
+
+It uses Subscription's spec.reply as spec.subscriber.
+
+This test should fail with https://github.com/knative/eventing/issues/5756 done.
+*/
+func TestChannelDeadLetterSinkByUsingReplyAsSubscriber(t *testing.T) {
+	// This test fails with our KafkaChannel here since the test assumes it is ok to leave Subscription's `spec.subscriber` empty.
+	// Leaving that empty is not handled in the data channel as there won't be any `egress.Destination` in the contract resource.
+	// Dataplane won't know what to do when the destination is empty.
+	// See https://github.com/knative/eventing/issues/5756#issuecomment-1012184663
+	t.Skip("We don't allow nil `spec.subscriber` in Subscription. See https://github.com/knative/eventing/issues/5756#issuecomment-1012184663")
+
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	createSubscriberFn := func(ref *duckv1.KReference, uri string) manifest.CfgFn {
+		return subscription.WithReply(ref, uri)
+	}
+	env.Test(ctx, t, channel.DeadLetterSink(createSubscriberFn))
+}
+
+/*
+TestEventTransformationForSubscription tests the following scenario:
+
+             1            2                 5            6                  7
+EventSource ---> Channel ---> Subscription ---> Channel ---> Subscription ----> Service(Logger)
+                                   |  ^
+                                 3 |  | 4
+                                   |  |
+                                   |  ---------
+                                   -----------> Service(Transformation)
+*/
+func TestEventTransformationForSubscriptionV1(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, channel.EventTransformation())
+}
+
+/*
+TestBinaryEventForChannel tests the following scenario:
+
+EventSource (binary-encoded messages) ---> Channel ---> Subscription ---> Service(Logger)
+
+*/
+func TestBinaryEventForChannel(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, channel.SingleEventWithEncoding(binding.EncodingBinary))
+}
+
+/*
+TestStructuredEventForChannel tests the following scenario:
+
+EventSource (structured-encoded messages) ---> Channel ---> Subscription ---> Service(Logger)
+
+*/
+func TestStructuredEventForChannel(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, channel.SingleEventWithEncoding(binding.EncodingStructured))
+}

--- a/test/e2e_new_channel/main_test.go
+++ b/test/e2e_new_channel/main_test.go
@@ -1,0 +1,71 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e_new_channel
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"knative.dev/eventing/test/rekt/resources/channel_impl"
+
+	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	"knative.dev/pkg/injection"
+	_ "knative.dev/pkg/system/testing"
+
+	"knative.dev/reconciler-test/pkg/environment"
+)
+
+// global is the singleton instance of GlobalEnvironment. It is used to parse
+// the testing config for the test run. The config will specify the cluster
+// config as well as the parsing level and state flags.
+var global environment.GlobalEnvironment
+
+func init() {
+	// environment.InitFlags registers state and level filter flags.
+	environment.InitFlags(flag.CommandLine)
+
+	// CHANNEL_GROUP_KIND=KafkaChannel.messaging.knative.dev;CHANNEL_VERSION=v1beta1
+	channel_impl.EnvCfg.ChannelGK = "KafkaChannel.messaging.knative.dev"
+	channel_impl.EnvCfg.ChannelV = "v1beta1"
+}
+
+// TestMain is the first entry point for `go test`.
+func TestMain(m *testing.M) {
+	// We get a chance to parse flags to include the framework flags for the
+	// framework as well as any additional flags included in the integration.
+	flag.Parse()
+
+	// EnableInjectionOrDie will enable client injection, this is used by the
+	// testing framework for namespace management, and could be leveraged by
+	// features to pull Kubernetes clients or the test environment out of the
+	// context passed in the features.
+	ctx, startInformers := injection.EnableInjectionOrDie(nil, nil) //nolint
+	startInformers()
+
+	// global is used to make instances of Environments, NewGlobalEnvironment
+	// is passing and saving the client injection enabled context for use later.
+	global = environment.NewGlobalEnvironment(ctx)
+
+	// Run the tests.
+	os.Exit(m.Run())
+}

--- a/test/experimental/features_config/features.yaml
+++ b/test/experimental/features_config/features.yaml
@@ -1,0 +1,29 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-features
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+    knative.dev/config-propagation: original
+    knative.dev/config-category: eventing
+data:
+  kreference-group: "disabled"
+  delivery-retryafter: "disabled"
+  delivery-timeout: "disabled"
+  strict-subscriber: "disabled"
+  new-trigger-filters: "enabled"

--- a/test/experimental/features_config/install.go
+++ b/test/experimental/features_config/install.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package features_config
+
+import (
+	"context"
+
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/manifest"
+)
+
+func Install(ctx context.Context, t feature.T) {
+	if _, err := manifest.InstallLocalYaml(ctx, map[string]interface{}{}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/experimental/main_test.go
+++ b/test/experimental/main_test.go
@@ -1,0 +1,65 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package experimental
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"knative.dev/pkg/injection"
+	_ "knative.dev/pkg/system/testing"
+
+	"knative.dev/reconciler-test/pkg/environment"
+)
+
+// global is the singleton instance of GlobalEnvironment. It is used to parse
+// the testing config for the test run. The config will specify the cluster
+// config as well as the parsing level and state flags.
+var global environment.GlobalEnvironment
+
+func init() {
+	// environment.InitFlags registers state and level filter flags.
+	environment.InitFlags(flag.CommandLine)
+}
+
+// TestMain is the first entry point for `go test`.
+func TestMain(m *testing.M) {
+	// We get a chance to parse flags to include the framework flags for the
+	// framework as well as any additional flags included in the integration.
+	flag.Parse()
+
+	// EnableInjectionOrDie will enable client injection, this is used by the
+	// testing framework for namespace management, and could be leveraged by
+	// features to pull Kubernetes clients or the test environment out of the
+	// context passed in the features.
+	ctx, startInformers := injection.EnableInjectionOrDie(nil, nil) //nolint
+
+	startInformers()
+
+	// global is used to make instances of Environments, NewGlobalEnvironment
+	// is passing and saving the client injection enabled context for use later.
+	global = environment.NewGlobalEnvironment(ctx)
+
+	// Run the tests.
+	os.Exit(m.Run())
+}

--- a/test/experimental/new_trigger_filters_test.go
+++ b/test/experimental/new_trigger_filters_test.go
@@ -1,0 +1,68 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2021 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package experimental
+
+import (
+	"testing"
+
+	"knative.dev/pkg/system"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/feature"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/knative"
+
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
+	"knative.dev/eventing-kafka-broker/test/e2e_new/single_partition_config"
+	"knative.dev/eventing-kafka-broker/test/experimental/features_config"
+
+	newfilters "knative.dev/eventing/test/experimental/features/new_trigger_filters"
+	"knative.dev/eventing/test/rekt/resources/broker"
+)
+
+func TestNewTriggerFilters(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+	brokerName := feature.MakeRandomK8sName("broker")
+
+	env.Prerequisite(ctx, t, InstallKafkaBrokerWithExperimentalFeatures(brokerName))
+	env.TestSet(ctx, t, newfilters.FiltersFeatureSet(brokerName))
+}
+
+func InstallKafkaBrokerWithExperimentalFeatures(name string) *feature.Feature {
+	f := feature.NewFeatureNamed("Kafka broker")
+	f.Setup("enable new trigger filters experimental feature", features_config.Install)
+	f.Setup("install one partition configuration", single_partition_config.Install)
+	f.Setup("install broker", broker.Install(
+		name,
+		broker.WithBrokerClass(kafka.BrokerClass),
+		broker.WithConfig(single_partition_config.ConfigMapName),
+	))
+	f.Setup("broker is ready", broker.IsReady(name))
+	f.Setup("broker is addressable", broker.IsAddressable(name))
+
+	return f
+}

--- a/test/kafka/kafka_setup.sh
+++ b/test/kafka/kafka_setup.sh
@@ -66,7 +66,7 @@ function create_tls_secrets() {
   ca_cert_secret="my-cluster-cluster-ca-cert"
   tls_user="my-tls-user"
 
-  echo "Waiting until secrets: ${ca_cert_secret}, ${tls_user} don't exist"
+  echo "Waiting until secrets: ${ca_cert_secret}, ${tls_user} exist"
   wait_until_object_exists secret ${ca_cert_secret} kafka
   wait_until_object_exists secret ${tls_user} kafka
 
@@ -80,6 +80,7 @@ function create_tls_secrets() {
     --from-literal=ca.crt="$STRIMZI_CRT" \
     --from-literal=user.crt="$TLSUSER_CRT" \
     --from-literal=user.key="$TLSUSER_KEY" \
+    --from-literal=protocol="SSL" \
     --dry-run=client -o yaml | kubectl apply -n "${SYSTEM_NAMESPACE}" -f -
 }
 
@@ -87,11 +88,11 @@ function create_sasl_secrets() {
   ca_cert_secret="my-cluster-cluster-ca-cert"
   sasl_user="my-sasl-user"
 
-  echo "Waiting until secrets: ${ca_cert_secret}, ${sasl_user} don't exist"
+  echo "Waiting until secrets: ${ca_cert_secret}, ${sasl_user} exist"
   wait_until_object_exists secret ${ca_cert_secret} kafka
   wait_until_object_exists secret ${sasl_user} kafka
 
-  echo "Creating SASL Kafka secret"
+  echo "Creating SASL_SSL and SASL_PLAINTEXT Kafka secrets"
 
   STRIMZI_CRT=$(kubectl -n kafka get secret ${ca_cert_secret} --template='{{index .data "ca.crt"}}' | base64 --decode )
   SASL_PASSWD=$(kubectl -n kafka get secret ${sasl_user} --template='{{index .data "password"}}' | base64 --decode )
@@ -99,8 +100,18 @@ function create_sasl_secrets() {
   kubectl create secret --namespace "${SYSTEM_NAMESPACE}" generic strimzi-sasl-secret \
     --from-literal=ca.crt="$STRIMZI_CRT" \
     --from-literal=password="$SASL_PASSWD" \
-    --from-literal=saslType="SCRAM-SHA-512" \
     --from-literal=user="my-sasl-user" \
+    --from-literal=protocol="SASL_SSL" \
+    --from-literal=sasl.mechanism="SCRAM-SHA-512" \
+    --from-literal=saslType="SCRAM-SHA-512" \
+    --dry-run=client -o yaml | kubectl apply -n "${SYSTEM_NAMESPACE}" -f -
+
+  kubectl create secret --namespace "${SYSTEM_NAMESPACE}" generic strimzi-sasl-plain-secret \
+    --from-literal=password="$SASL_PASSWD" \
+    --from-literal=user="my-sasl-user" \
+    --from-literal=protocol="SASL_PLAINTEXT" \
+    --from-literal=sasl.mechanism="SCRAM-SHA-512" \
+    --from-literal=saslType="SCRAM-SHA-512" \
     --dry-run=client -o yaml | kubectl apply -n "${SYSTEM_NAMESPACE}" -f -
 }
 

--- a/test/pkg/addressable/send.go
+++ b/test/pkg/addressable/send.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apiserver/pkg/storage/names"
 	testlib "knative.dev/eventing/test/lib"
-	pkgtest "knative.dev/pkg/test"
 )
 
 type EventMutator func(event *cloudevents.Event)
@@ -54,8 +53,6 @@ func SendN(t *testing.T, n int, addressable Addressable, mutators ...EventMutato
 				go func(i int) {
 
 					client, err := testlib.NewClient(
-						pkgtest.Flags.Kubeconfig,
-						pkgtest.Flags.Cluster,
 						addressable.Namespace,
 						t,
 					)

--- a/test/pkg/broker/broker.go
+++ b/test/pkg/broker/broker.go
@@ -28,7 +28,7 @@ import (
 	"knative.dev/eventing/test/lib/resources"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	testingpkg "knative.dev/eventing-kafka-broker/test/pkg/testing"
 )
 

--- a/test/reconciler-tests.sh
+++ b/test/reconciler-tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+source $(dirname $0)/e2e-common.sh
+
+if ! ${SKIP_INITIALIZE}; then
+  initialize $@ --skip-istio-addon
+  save_release_artifacts || fail_test "Failed to save release artifacts"
+fi
+
+if ! ${LOCAL_DEVELOPMENT}; then
+  scale_controlplane kafka-controller kafka-webhook-eventing eventing-webhook eventing-controller
+  apply_sacura || fail_test "Failed to apply Sacura"
+  apply_chaos || fail_test "Failed to apply chaos"
+fi
+
+header "Waiting Knative eventing to come up"
+
+wait_until_pods_running knative-eventing || fail_test "Pods in knative-eventing didn't come up"
+
+export_logs_continuously
+
+header "Running tests"
+
+if [ "${EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO:-""}" != "" ]; then
+  # if this flag exists, only test Kafka channel scenarios with auth
+  $(dirname $0)/channel-reconciler-tests.sh || fail_test "Failed to execute KafkaChannel tests"
+  success
+fi
+
+go_test_e2e -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
+
+go_test_e2e -tags=e2e,cloudevents -timeout=1h ./test/e2e_new_channel/... || fail_test "E2E (new - KafkaChannel) suite failed"
+
+go_test_e2e -tags=deletecm ./test/e2e_new/... || fail_test "E2E (new deletecm) suite failed"
+
+if ! ${LOCAL_DEVELOPMENT}; then
+  go_test_e2e -tags=sacura -timeout=40m ./test/e2e/... || fail_test "E2E (sacura) suite failed"
+fi
+
+success

--- a/test/test_images/kafka-consumer/consumer.go
+++ b/test/test_images/kafka-consumer/consumer.go
@@ -33,7 +33,7 @@ import (
 	"knative.dev/pkg/signals"
 
 	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	kafkatest "knative.dev/eventing-kafka-broker/test/pkg/kafka"
 )
 

--- a/test/upgrade/continual.go
+++ b/test/upgrade/continual.go
@@ -22,11 +22,27 @@ import (
 	"knative.dev/eventing-kafka-broker/test/upgrade/continual"
 )
 
+// ContinualTests returns all continual tests.
+func ContinualTests() []pkgupgrade.BackgroundOperation {
+	c := BrokerContinualTests()
+	c = append(c, SinkContinualTests()...)
+	return c
+}
+
 // BrokerContinualTests returns background operations to test broker
 // functionality in continual manner during the whole upgrade and downgrade
 // process asserting that all events are propagated.
 func BrokerContinualTests() []pkgupgrade.BackgroundOperation {
 	return []pkgupgrade.BackgroundOperation{
 		continual.BrokerTest(continual.KafkaBrokerTestOptions{}),
+	}
+}
+
+// SinkContinualTests returns background operations to test KafkaSink
+// functionality in continual manner during the whole upgrade and downgrade
+// process asserting that all events are propagated.
+func SinkContinualTests() []pkgupgrade.BackgroundOperation {
+	return []pkgupgrade.BackgroundOperation{
+		continual.SinkSourceTest(continual.KafkaSinkSourceTestOptions{}),
 	}
 }

--- a/test/upgrade/continual/broker.go
+++ b/test/upgrade/continual/broker.go
@@ -35,7 +35,7 @@ import (
 
 	eventingkafkaupgrade "knative.dev/eventing-kafka/test/upgrade/continual"
 
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/kafka"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	testingpkg "knative.dev/eventing-kafka-broker/test/pkg/testing"
 )
 

--- a/test/upgrade/continual/kafka-sink-source-config.toml
+++ b/test/upgrade/continual/kafka-sink-source-config.toml
@@ -1,0 +1,7 @@
+# logLevel = 'DEBUG'
+[sender]
+address = '{{- .Endpoint -}}'
+interval = {{ .Config.Interval.Nanoseconds }}
+
+[forwarder]
+target = 'http://wathola-receiver.{{- .Namespace -}}.svc.cluster.local'

--- a/test/upgrade/continual/sink_source.go
+++ b/test/upgrade/continual/sink_source.go
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2022 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package continual
+
+import (
+	"fmt"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	bindings "knative.dev/eventing-kafka/pkg/apis/bindings/v1beta1"
+	sources "knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
+	eventingkafkaupgrade "knative.dev/eventing-kafka/test/upgrade/continual"
+	"knative.dev/eventing/test/upgrade/prober/sut"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	pkgupgrade "knative.dev/pkg/test/upgrade"
+
+	eventingkafkatestlib "knative.dev/eventing-kafka/test/lib"
+
+	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	eventingv1alpha1clientset "knative.dev/eventing-kafka-broker/control-plane/pkg/client/clientset/versioned/typed/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/test/pkg/sink"
+	testingpkg "knative.dev/eventing-kafka-broker/test/pkg/testing"
+)
+
+const (
+	kafkaSinkConfigTemplate = "test/upgrade/continual/kafka-sink-source-config.toml"
+
+	defaultTopic = "kafka-sink-source-continual-test-topic"
+)
+
+type KafkaSinkSourceTestOptions struct {
+	*eventingkafkaupgrade.TestOptions
+	*Sink
+	*Source
+}
+
+func (o *KafkaSinkSourceTestOptions) setDefaults() {
+	if o.TestOptions == nil {
+		o.TestOptions = &eventingkafkaupgrade.TestOptions{}
+	}
+	if o.Sink == nil {
+		rf := int16(3)
+		o.Sink = &Sink{
+			Name: "sink-kafka-sink-source-continual-test",
+			Spec: eventing.KafkaSinkSpec{
+				Topic:             defaultTopic,
+				NumPartitions:     pointer.Int32(10),
+				ReplicationFactor: &rf,
+				BootstrapServers:  []string{testingpkg.BootstrapServersPlaintext},
+			},
+		}
+	}
+	if o.Source == nil {
+		o.Source = &Source{
+			Name: "source-kafka-sink-source-continual-test",
+			Spec: sources.KafkaSourceSpec{
+				Topics:        []string{defaultTopic},
+				ConsumerGroup: "source-kafka-sink-source-continual-test-consumer-group",
+				InitialOffset: sources.OffsetEarliest,
+				KafkaAuthSpec: bindings.KafkaAuthSpec{
+					BootstrapServers: []string{testingpkg.BootstrapServersPlaintext},
+				},
+			},
+		}
+	}
+}
+
+func (o *KafkaSinkSourceTestOptions) validate() error {
+	if len(o.Source.Spec.Topics) != 1 || o.Sink.Spec.Topic != o.Source.Spec.Topics[0] {
+		return fmt.Errorf("expected sink and source topic to be the same topic, source topics %v, sink topic %v", o.Source.Spec.Topics, o.Sink.Spec.Topic)
+	}
+	return nil
+}
+
+type kafkaSinkSourceSut struct {
+	Sink
+	Source
+}
+
+func (k kafkaSinkSourceSut) Deploy(ctx sut.Context, destination duckv1.Destination) interface{} {
+	k.deploySink(ctx)
+	k.deploySource(ctx, destination)
+	url := k.fetchUrl(ctx)
+	return url
+}
+
+func (k kafkaSinkSourceSut) deploySink(ctx sut.Context) {
+	clientSet, err := eventingv1alpha1clientset.NewForConfig(ctx.Config)
+	require.Nil(ctx.T, err)
+
+	s := types.NamespacedName{
+		Namespace: ctx.Client.Namespace,
+		Name:      k.Sink.Name,
+	}
+	if _, err = sink.CreatorV1Alpha1(clientSet, k.Sink.Spec)(s); err != nil {
+		ctx.T.Fatalf("failed to create KafkaSink %+v: %v", s, err)
+	}
+}
+
+func (k kafkaSinkSourceSut) deploySource(ctx sut.Context, destination duckv1.Destination) {
+	ks := &sources.KafkaSource{
+		TypeMeta: metav1.TypeMeta{Kind: "KafkaSource", APIVersion: sources.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k.Source.Name,
+			Namespace: ctx.Client.Namespace,
+		},
+		Spec: *k.Source.Spec.DeepCopy(),
+	}
+	ks.Spec.Sink = destination
+	eventingkafkatestlib.CreateKafkaSourceV1Beta1OrFail(ctx.Client, ks)
+}
+
+func (k kafkaSinkSourceSut) fetchUrl(ctx sut.Context) *apis.URL {
+	tm := &metav1.TypeMeta{
+		Kind:       "KafkaSink",
+		APIVersion: eventing.SchemeGroupVersion.String(),
+	}
+	ctx.Client.WaitForResourceReadyOrFail(k.Sink.Name, tm)
+	address, err := ctx.Client.GetAddressableURI(k.Sink.Name, tm)
+	require.Nil(ctx.T, err, "Failed to get address from sink %s", k.Sink.Name)
+
+	url, _ := apis.ParseURL(address)
+	return url
+}
+
+func SinkSourceTest(opts KafkaSinkSourceTestOptions) pkgupgrade.BackgroundOperation {
+	opts.setDefaults()
+	if err := opts.validate(); err != nil {
+		panic(err)
+	}
+	return continualVerification(
+		"KafkaSinkSourceContinualTest",
+		opts.TestOptions,
+		&kafkaSinkSourceSut{Sink: *opts.Sink, Source: *opts.Source},
+		kafkaSinkConfigTemplate,
+	)
+}

--- a/test/upgrade/continual/types.go
+++ b/test/upgrade/continual/types.go
@@ -17,10 +17,13 @@
 package continual
 
 import (
+	sources "knative.dev/eventing-kafka/pkg/apis/sources/v1beta1"
 	eventingkafkaupgrade "knative.dev/eventing-kafka/test/upgrade/continual"
 	"knative.dev/eventing/test/upgrade/prober"
 	"knative.dev/eventing/test/upgrade/prober/sut"
 	"knative.dev/eventing/test/upgrade/prober/wathola/event"
+
+	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
 )
 
 // TestOptions holds options for EventingKafka continual tests.
@@ -37,6 +40,16 @@ type Broker struct {
 	Name string
 	*eventingkafkaupgrade.ReplicationOptions
 	*eventingkafkaupgrade.RetryOptions
+}
+
+type Sink struct {
+	Name string
+	Spec eventing.KafkaSinkSpec
+}
+
+type Source struct {
+	Name string
+	Spec sources.KafkaSourceSpec
 }
 
 var eventTypes = []string{

--- a/test/upgrade/postdowngrade.go
+++ b/test/upgrade/postdowngrade.go
@@ -18,6 +18,9 @@ package upgrade
 
 import (
 	pkgupgrade "knative.dev/pkg/test/upgrade"
+
+	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/test/e2e"
 )
 
 // BrokerPostDowngradeTest tests channel basic channel operations after
@@ -25,5 +28,12 @@ import (
 func BrokerPostDowngradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("BrokerPostDowngradeTest", func(c pkgupgrade.Context) {
 		runBrokerSmokeTest(c.T)
+	})
+}
+
+// SinkPostDowngradeTest tests sink basic operations after downgrade.
+func SinkPostDowngradeTest() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation("SinkPostDowngradeTest", func(c pkgupgrade.Context) {
+		e2e.RunTestKafkaSink(c.T, eventing.ModeBinary, nil)
 	})
 }

--- a/test/upgrade/postupgrade.go
+++ b/test/upgrade/postupgrade.go
@@ -17,12 +17,84 @@
 package upgrade
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/pkg/system"
 	pkgupgrade "knative.dev/pkg/test/upgrade"
+
+	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/test/e2e"
 )
 
 // BrokerPostUpgradeTest tests channel operations after upgrade.
 func BrokerPostUpgradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("BrokerPostUpgradeTest", func(c pkgupgrade.Context) {
-		runBrokerSmokeTest(c.T)
+		c.T.Parallel()
+		c.T.Run("Verify post-install", func(t *testing.T) {
+			verifyPostInstall(t)
+		})
+		c.T.Run("tests", func(t *testing.T) {
+			runBrokerSmokeTest(t)
+		})
 	})
+}
+
+// SinkPostUpgradeTest tests sink basic operations post upgrade.
+func SinkPostUpgradeTest() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation("SinkPostUpgradeTest", func(c pkgupgrade.Context) {
+		c.T.Parallel()
+		c.T.Run("Verify post-install", func(t *testing.T) {
+			verifyPostInstall(t)
+		})
+		c.T.Run("tests", func(t *testing.T) {
+			e2e.RunTestKafkaSink(t, eventing.ModeBinary, nil)
+		})
+	})
+}
+
+func verifyPostInstall(t *testing.T) {
+	t.Parallel()
+
+	const (
+		postInstallJob            = "kafka-controller-post-install"
+		storageVersionMigratorJob = "knative-kafka-storage-version-migrator"
+	)
+	for _, name := range []string{postInstallJob, storageVersionMigratorJob} {
+		t.Run(name, func(t *testing.T) {
+			client := testlib.Setup(t, true)
+			defer testlib.TearDown(client)
+
+			var lastJob *batchv1.Job
+			err := wait.Poll(5*time.Second, 10*time.Minute, func() (done bool, err error) {
+				lastJob, err = client.Kube.
+					BatchV1().
+					Jobs(system.Namespace()).
+					Get(context.Background(), name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+
+				if lastJob.Status.Failed == *lastJob.Spec.BackoffLimit {
+					return false, fmt.Errorf("job %s failed", name)
+				}
+
+				return lastJob.Status.Succeeded > 0, nil
+			})
+			if err != nil {
+				j := []byte("unknown")
+				if lastJob != nil {
+					j, _ = json.Marshal(lastJob)
+				}
+				t.Fatal(err, "\njob:\n", string(j))
+			}
+		})
+	}
 }

--- a/test/upgrade/preupgrade.go
+++ b/test/upgrade/preupgrade.go
@@ -18,11 +18,21 @@ package upgrade
 
 import (
 	pkgupgrade "knative.dev/pkg/test/upgrade"
+
+	eventing "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/eventing/v1alpha1"
+	"knative.dev/eventing-kafka-broker/test/e2e"
 )
 
 // BrokerPreUpgradeTest tests channel operations before upgrade.
 func BrokerPreUpgradeTest() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("BrokerPreUpgradeTest", func(c pkgupgrade.Context) {
 		runBrokerSmokeTest(c.T)
+	})
+}
+
+// SinkPreUpgradeTest tests sink basic operations pre upgrade.
+func SinkPreUpgradeTest() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation("SinkPreUpgradeTest", func(c pkgupgrade.Context) {
+		e2e.RunTestKafkaSink(c.T, eventing.ModeBinary, nil)
 	})
 }

--- a/test/upgrade/suite.go
+++ b/test/upgrade/suite.go
@@ -28,14 +28,17 @@ func Suite() pkgupgrade.Suite {
 		Tests: pkgupgrade.Tests{
 			PreUpgrade: []pkgupgrade.Operation{
 				BrokerPreUpgradeTest(),
+				SinkPreUpgradeTest(),
 			},
 			PostUpgrade: []pkgupgrade.Operation{
 				BrokerPostUpgradeTest(),
+				SinkPostUpgradeTest(),
 			},
 			PostDowngrade: []pkgupgrade.Operation{
 				BrokerPostDowngradeTest(),
+				SinkPostDowngradeTest(),
 			},
-			Continual: BrokerContinualTests(),
+			Continual: ContinualTests(),
 		},
 		Installations: pkgupgrade.Installations{
 			Base: []pkgupgrade.Operation{

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -22,19 +22,10 @@ package upgrade
 import (
 	"testing"
 
-	"go.uber.org/zap"
 	pkgupgrade "knative.dev/pkg/test/upgrade"
 )
 
 func TestUpgrades(t *testing.T) {
 	suite := Suite()
-	suite.Execute(newUpgradeConfig(t))
-}
-
-func newUpgradeConfig(t *testing.T) pkgupgrade.Configuration {
-	log, err := zap.NewDevelopment()
-	if err != nil {
-		t.Fatal(err)
-	}
-	return pkgupgrade.Configuration{T: t, Log: log}
+	suite.Execute(pkgupgrade.Configuration{T: t})
 }


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

**NOTE:** I recreated branch `release-v1.2` from the 1.1 release branch...

Here I am adding (`copy -r`) the entire test folder from upstream `1.2` branch (not tag)

Let's not worry about CI on this - I will re-adjust that once we have a bit of more clear structure here 

NEXT: PR to bump the version.... on the CI manifests 