### PR TITLE
[release-v1.2] Update the manifests to 1.2.3

### DIFF
--- a/openshift/release/knative-eventing-kafka-broker-cp-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-broker-cp-ci.yaml
@@ -6,7 +6,7 @@ metadata:
   name: kafka-broker-config
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 data:
   default.topic.partitions: "10"
   default.topic.replication.factor: "3"
@@ -19,7 +19,7 @@ metadata:
   labels:
     duck.knative.dev/addressable: "true"
     knative.dev/crd-install: "true"
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 spec:
   group: eventing.knative.dev
   names:
@@ -243,7 +243,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: eventing-kafka-source-observer
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:
@@ -259,7 +259,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
   name: config-kafka-leader-election
   namespace: knative-eventing
   annotations:
@@ -281,7 +281,7 @@ metadata:
   name: kafka-config-logging
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 data:
   config.xml: |
     <configuration>
@@ -298,7 +298,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-kafka-addressable-resolver
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
     duck.knative.dev/addressable: "true"
 rules:
   - apiGroups:
@@ -325,7 +325,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channelable-manipulator
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
     duck.knative.dev/channelable: "true"
 rules:
   - apiGroups:
@@ -348,7 +348,7 @@ kind: ClusterRole
 metadata:
   name: kafka-controller
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 rules:
   - apiGroups:
       - "*"
@@ -510,7 +510,7 @@ metadata:
   name: kafka-controller
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 ---
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -518,7 +518,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -533,7 +533,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller-addressable-resolver
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -551,7 +551,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 spec:
   selector:
     matchLabels:
@@ -561,7 +561,7 @@ spec:
       name: kafka-controller
       labels:
         app: kafka-controller
-        kafka.eventing.knative.dev/release: v1.1.3
+        kafka.eventing.knative.dev/release: v1.2.3
     spec:
       securityContext:
         runAsNonRoot: false
@@ -577,7 +577,7 @@ spec:
               weight: 100
       containers:
         - name: controller
-          image: registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-kafka-controller
+          image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-kafka-controller
           imagePullPolicy: IfNotPresent
           env:
             - name: BROKER_DATA_PLANE_CONFIG_MAP_NAMESPACE
@@ -677,7 +677,7 @@ kind: ClusterRole
 metadata:
   name: kafka-webhook-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 rules:
   - apiGroups:
       - ""
@@ -758,7 +758,7 @@ metadata:
   name: kafka-webhook-eventing
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 ---
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -766,7 +766,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-webhook-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 subjects:
   - kind: ServiceAccount
     name: kafka-webhook-eventing
@@ -781,7 +781,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 webhooks:
   - admissionReviewVersions: [ "v1", "v1beta1" ]
     clientConfig:
@@ -799,14 +799,14 @@ metadata:
   name: kafka-webhook-eventing-certs
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kafka.eventing.knative.dev
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -825,7 +825,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 spec:
   selector:
     matchLabels:
@@ -834,7 +834,7 @@ spec:
     metadata:
       labels:
         app: kafka-webhook-eventing
-        kafka.eventing.knative.dev/release: v1.1.3
+        kafka.eventing.knative.dev/release: v1.2.3
     spec:
       affinity:
         podAntiAffinity:
@@ -851,7 +851,7 @@ spec:
       containers:
         - name: kafka-webhook-eventing
           terminationMessagePolicy: FallbackToLogsOnError
-          image: registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-webhook-kafka
+          image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-webhook-kafka
           resources:
             requests:
               cpu: 20m
@@ -907,7 +907,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 spec:
   ports:
     - name: https-webhook

--- a/openshift/release/knative-eventing-kafka-broker-dp-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-broker-dp-ci.yaml
@@ -6,7 +6,7 @@ metadata:
   name: config-kafka-broker-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 data:
   config-kafka-broker-producer.properties: |
     key.serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -72,7 +72,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-broker-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 rules:
   - apiGroups:
       - "*"
@@ -90,7 +90,7 @@ metadata:
   name: knative-kafka-broker-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 ---
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -98,7 +98,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-broker-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-broker-data-plane
@@ -116,7 +116,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-dispatcher
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 spec:
   selector:
     matchLabels:
@@ -126,14 +126,14 @@ spec:
       name: kafka-broker-dispatcher
       labels:
         app: kafka-broker-dispatcher
-        kafka.eventing.knative.dev/release: v1.1.3
+        kafka.eventing.knative.dev/release: v1.2.3
     spec:
       serviceAccountName: knative-kafka-broker-data-plane
       securityContext:
         runAsNonRoot: false
       containers:
         - name: kafka-broker-dispatcher
-          image: registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-dispatcher
+          image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-dispatcher
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -249,7 +249,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 spec:
   selector:
     matchLabels:
@@ -259,7 +259,7 @@ spec:
       name: kafka-broker-receiver
       labels:
         app: kafka-broker-receiver
-        kafka.eventing.knative.dev/release: v1.1.3
+        kafka.eventing.knative.dev/release: v1.2.3
     spec:
       serviceAccountName: knative-kafka-broker-data-plane
       securityContext:
@@ -275,7 +275,7 @@ spec:
               weight: 100
       containers:
         - name: kafka-broker-receiver
-          image: registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-receiver
+          image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-receiver
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -388,7 +388,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 spec:
   selector:
     app: kafka-broker-receiver
@@ -410,7 +410,7 @@ metadata:
   name: config-kafka-sink-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 data:
   config-kafka-sink-producer.properties: |
     key.serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -446,7 +446,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-sink-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 rules:
   - apiGroups:
       - "*"
@@ -464,7 +464,7 @@ metadata:
   name: knative-kafka-sink-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 ---
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -472,7 +472,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-sink-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-sink-data-plane
@@ -490,7 +490,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 spec:
   selector:
     matchLabels:
@@ -500,7 +500,7 @@ spec:
       name: kafka-sink-receiver
       labels:
         app: kafka-sink-receiver
-        kafka.eventing.knative.dev/release: v1.1.3
+        kafka.eventing.knative.dev/release: v1.2.3
     spec:
       serviceAccountName: knative-kafka-sink-data-plane
       securityContext:
@@ -516,7 +516,7 @@ spec:
               weight: 100
       containers:
         - name: kafka-sink-receiver
-          image: registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-receiver
+          image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-receiver
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -629,7 +629,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 spec:
   selector:
     app: kafka-sink-receiver
@@ -651,7 +651,7 @@ metadata:
   name: config-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 data:
   config-kafka-source-producer.properties: |
     key.serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -717,7 +717,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 rules:
   - apiGroups:
       - "*"
@@ -735,7 +735,7 @@ metadata:
   name: knative-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 ---
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -743,7 +743,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-source-data-plane
@@ -761,7 +761,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-source-dispatcher
-    kafka.eventing.knative.dev/release: v1.1.3
+    kafka.eventing.knative.dev/release: v1.2.3
 spec:
   selector:
     matchLabels:
@@ -771,14 +771,14 @@ spec:
       name: kafka-source-dispatcher
       labels:
         app: kafka-source-dispatcher
-        kafka.eventing.knative.dev/release: v1.1.3
+        kafka.eventing.knative.dev/release: v1.2.3
     spec:
       serviceAccountName: knative-kafka-source-data-plane
       securityContext:
         runAsNonRoot: false
       containers:
         - name: kafka-source-dispatcher
-          image: registry.ci.openshift.org/openshift/knative-v1.1.3:knative-eventing-kafka-broker-dispatcher
+          image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-dispatcher
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

**NOTE:** I recreated branch `release-v1.2` from the 1.1 release branch...

Here I bump the version.... on the CI manifests, to match the latest 1.2x release from upstream 