### PR TITLE
[release-v1.1] KafkaSource lease remapping

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-leader-election.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-leader-election.yaml
@@ -45,3 +45,5 @@ data:
   leaseDuration: "15s"
   renewDeadline: "10s"
   retryPeriod: "2s"
+  map-lease-prefix.kafka-broker-controller.knative.dev.eventing-kafka-broker.control-plane.pkg.reconciler.source.Reconciler: kafka-controller.knative.dev.eventing-kafka.pkg.source.reconciler.source.reconciler
+  map-lease-prefix.kafka-broker-controller.knative.dev.eventing-kafka-broker.control-plane.pkg.reconciler.channel.Reconciler: kafkachannel-controller.knative.dev.eventing-kafka.pkg.channel.consolidated.reconciler.controller.reconciler

--- a/hack/control-plane.sh
+++ b/hack/control-plane.sh
@@ -20,6 +20,6 @@ readonly CONTROL_PLANE_CONFIG_DIR=control-plane/config
 
 # Note: do not change this function name, it's used during releases.
 function control_plane_setup() {
-  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >>"${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}"
-  return $?
+  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >"${EVENTING_KAFKA_CONTROL_PLANE_ARTIFACT}" || return $?
+  ko resolve ${KO_FLAGS} -Rf "${CONTROL_PLANE_POST_INSTALL_CONFIG_DIR}" | "${LABEL_YAML_CMD[@]}" >"${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" || return $?
 }

--- a/openshift/patches/support-map-lease-prefix-in-pkg.patch
+++ b/openshift/patches/support-map-lease-prefix-in-pkg.patch
@@ -1,0 +1,102 @@
+diff --git a/vendor/knative.dev/pkg/configmap/parse.go b/vendor/knative.dev/pkg/configmap/parse.go
+index e93f9af2..e733e383 100644
+--- a/vendor/knative.dev/pkg/configmap/parse.go
++++ b/vendor/knative.dev/pkg/configmap/parse.go
+@@ -244,3 +244,24 @@ func Parse(data map[string]string, parsers ...ParseFunc) error {
+ 	}
+ 	return nil
+ }
++
++// CollectMapEntriesWithPrefix parses the data into the target as a map[string]string, if it exists.
++// The map is represented as a list of key-value pairs with a common prefix.
++func CollectMapEntriesWithPrefix(prefix string, target *map[string]string) ParseFunc {
++	if target == nil {
++		panic("target cannot be nil")
++	}
++
++	return func(data map[string]string) error {
++		for k, v := range data {
++			if strings.HasPrefix(k, prefix) && len(k) > len(prefix)+1 {
++				if *target == nil {
++					m := make(map[string]string, 2)
++					*target = m
++				}
++				(*target)[k[len(prefix)+1: /* remove dot `.` */]] = v
++			}
++		}
++		return nil
++	}
++}
+diff --git a/vendor/knative.dev/pkg/leaderelection/config.go b/vendor/knative.dev/pkg/leaderelection/config.go
+index 0694395b..b420009c 100644
+--- a/vendor/knative.dev/pkg/leaderelection/config.go
++++ b/vendor/knative.dev/pkg/leaderelection/config.go
+@@ -56,6 +56,8 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
+ 		cm.AsDuration("retry-period", &config.RetryPeriod),
+ 
+ 		cm.AsUint32("buckets", &config.Buckets),
++
++		cm.CollectMapEntriesWithPrefix("map-lease-prefix", &config.LeaseNamesPrefixMapping),
+ 	); err != nil {
+ 		return nil, err
+ 	}
+@@ -79,19 +81,21 @@ func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
+ // contained within a single namespace. Typically these will correspond to a
+ // single source repository, viz: serving or eventing.
+ type Config struct {
+-	Buckets       uint32
+-	LeaseDuration time.Duration
+-	RenewDeadline time.Duration
+-	RetryPeriod   time.Duration
++	Buckets                 uint32
++	LeaseDuration           time.Duration
++	RenewDeadline           time.Duration
++	RetryPeriod             time.Duration
++	LeaseNamesPrefixMapping map[string]string
+ }
+ 
+ func (c *Config) GetComponentConfig(name string) ComponentConfig {
+ 	return ComponentConfig{
+-		Component:     name,
+-		Buckets:       c.Buckets,
+-		LeaseDuration: c.LeaseDuration,
+-		RenewDeadline: c.RenewDeadline,
+-		RetryPeriod:   c.RetryPeriod,
++		Component:               name,
++		Buckets:                 c.Buckets,
++		LeaseDuration:           c.LeaseDuration,
++		RenewDeadline:           c.RenewDeadline,
++		RetryPeriod:             c.RetryPeriod,
++		LeaseNamesPrefixMapping: c.LeaseNamesPrefixMapping,
+ 	}
+ }
+ 
+@@ -123,6 +127,11 @@ type ComponentConfig struct {
+ 	// be generated to be used as identity for each BuildElector call.
+ 	// Autoscaler uses the pod IP as identity.
+ 	Identity string
++
++	// LeaseNamesPrefixMapping maps lease prefixes
++	// from <component>.<package>.<reconciler_type_name> to the
++	// associated value when using standardBuilder.
++	LeaseNamesPrefixMapping map[string]string
+ }
+ 
+ // statefulSetID is a envconfig Decodable controller ordinal and name.
+diff --git a/vendor/knative.dev/pkg/leaderelection/context.go b/vendor/knative.dev/pkg/leaderelection/context.go
+index 4758ccba..7919e126 100644
+--- a/vendor/knative.dev/pkg/leaderelection/context.go
++++ b/vendor/knative.dev/pkg/leaderelection/context.go
+@@ -192,7 +192,11 @@ func newStandardBuckets(queueName string, cc ComponentConfig) []reconciler.Bucke
+ }
+ 
+ func standardBucketName(ordinal uint32, queueName string, cc ComponentConfig) string {
+-	return strings.ToLower(fmt.Sprintf("%s.%s.%02d-of-%02d", cc.Component, queueName, ordinal, cc.Buckets))
++	prefix := fmt.Sprintf("%s.%s", cc.Component, queueName)
++	if v, ok := cc.LeaseNamesPrefixMapping[prefix]; ok && len(v) > 0 {
++		prefix = v
++	}
++	return strings.ToLower(fmt.Sprintf("%s.%02d-of-%02d", prefix, ordinal, cc.Buckets))
+ }
+ 
+ type statefulSetBuilder struct {

--- a/openshift/release/knative-eventing-kafka-broker-cp-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-broker-cp-ci.yaml
@@ -273,6 +273,8 @@ data:
   leaseDuration: "15s"
   renewDeadline: "10s"
   retryPeriod: "2s"
+  map-lease-prefix.kafka-broker-controller.knative.dev.eventing-kafka-broker.control-plane.pkg.reconciler.source.Reconciler: kafka-controller.knative.dev.eventing-kafka.pkg.source.reconciler.source.reconciler
+  map-lease-prefix.kafka-broker-controller.knative.dev.eventing-kafka-broker.control-plane.pkg.reconciler.channel.Reconciler: kafkachannel-controller.knative.dev.eventing-kafka.pkg.channel.consolidated.reconciler.controller.reconciler
 ---
 ---
 apiVersion: v1

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -90,6 +90,8 @@ function build_components_from_source() {
   [ -f "${EVENTING_KAFKA_SOURCE_ARTIFACT}" ] && rm "${EVENTING_KAFKA_SOURCE_ARTIFACT}"
   [ -f "${EVENTING_KAFKA_BROKER_ARTIFACT}" ] && rm "${EVENTING_KAFKA_BROKER_ARTIFACT}"
   [ -f "${EVENTING_KAFKA_SINK_ARTIFACT}" ] && rm "${EVENTING_KAFKA_SINK_ARTIFACT}"
+  [ -f "${EVENTING_KAFKA_CHANNEL_ARTIFACT}" ] && rm "${EVENTING_KAFKA_CHANNEL_ARTIFACT}"
+  [ -f "${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}" ] && rm "${EVENTING_KAFKA_POST_INSTALL_ARTIFACT}"
 
   header "Data plane setup"
   data_plane_setup || fail_test "Failed to set up data plane components"

--- a/test/e2e_new/features/leases.go
+++ b/test/e2e_new/features/leases.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package features
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/system"
+	"knative.dev/reconciler-test/pkg/feature"
+)
+
+func KafkaChannelLease() *feature.Feature {
+	f := feature.NewFeatureNamed("KafkaChannel lease")
+
+	f.Assert("verify lease name", verifyLeaseAcquired(
+		"kafkachannel-controller.knative.dev.eventing-kafka.pkg.channel.consolidated.reconciler.controller.reconciler.00-of-01",
+	))
+
+	return f
+}
+
+func KafkaSourceLease() *feature.Feature {
+	f := feature.NewFeatureNamed("KafkaSource lease")
+
+	f.Assert("verify lease name", verifyLeaseAcquired(
+		"kafka-controller.knative.dev.eventing-kafka.pkg.source.reconciler.source.reconciler.00-of-01",
+	))
+
+	return f
+}
+
+func verifyLeaseAcquired(name string) feature.StepFn {
+	return func(ctx context.Context, t feature.T) {
+		err := wait.Poll(time.Second, time.Minute, func() (done bool, err error) {
+			lease, err := kubeclient.Get(ctx).
+				CoordinationV1().
+				Leases(system.Namespace()).
+				Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal("failed to get lease %s/%s: %v", system.Namespace(), name, err)
+			}
+
+			return lease.Spec.HolderIdentity != nil &&
+				strings.HasPrefix(*lease.Spec.HolderIdentity, "kafka-controller"), nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/test/e2e_new/lease_test.go
+++ b/test/e2e_new/lease_test.go
@@ -1,0 +1,46 @@
+//go:build e2e
+// +build e2e
+
+/*
+ * Copyright 2022 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package e2e_new
+
+import (
+	"testing"
+
+	"knative.dev/pkg/system"
+	"knative.dev/reconciler-test/pkg/environment"
+	"knative.dev/reconciler-test/pkg/k8s"
+	"knative.dev/reconciler-test/pkg/knative"
+
+	"knative.dev/eventing-kafka-broker/test/e2e_new/features"
+)
+
+func TestLeaseAcquired(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, features.KafkaChannelLease())
+	env.Test(ctx, t, features.KafkaSourceLease())
+}

--- a/test/e2e_new/lease_test.go
+++ b/test/e2e_new/lease_test.go
@@ -41,6 +41,6 @@ func TestLeaseAcquired(t *testing.T) {
 		environment.Managed(t),
 	)
 
-	env.Test(ctx, t, features.KafkaChannelLease())
+	// env.Test(ctx, t, features.KafkaChannelLease())
 	env.Test(ctx, t, features.KafkaSourceLease())
 }

--- a/vendor/knative.dev/pkg/configmap/parse.go
+++ b/vendor/knative.dev/pkg/configmap/parse.go
@@ -244,3 +244,24 @@ func Parse(data map[string]string, parsers ...ParseFunc) error {
 	}
 	return nil
 }
+
+// CollectMapEntriesWithPrefix parses the data into the target as a map[string]string, if it exists.
+// The map is represented as a list of key-value pairs with a common prefix.
+func CollectMapEntriesWithPrefix(prefix string, target *map[string]string) ParseFunc {
+	if target == nil {
+		panic("target cannot be nil")
+	}
+
+	return func(data map[string]string) error {
+		for k, v := range data {
+			if strings.HasPrefix(k, prefix) && len(k) > len(prefix)+1 {
+				if *target == nil {
+					m := make(map[string]string, 2)
+					*target = m
+				}
+				(*target)[k[len(prefix)+1: /* remove dot `.` */]] = v
+			}
+		}
+		return nil
+	}
+}

--- a/vendor/knative.dev/pkg/leaderelection/config.go
+++ b/vendor/knative.dev/pkg/leaderelection/config.go
@@ -56,6 +56,8 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		cm.AsDuration("retry-period", &config.RetryPeriod),
 
 		cm.AsUint32("buckets", &config.Buckets),
+
+		cm.CollectMapEntriesWithPrefix("map-lease-prefix", &config.LeaseNamesPrefixMapping),
 	); err != nil {
 		return nil, err
 	}
@@ -79,19 +81,21 @@ func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
 // contained within a single namespace. Typically these will correspond to a
 // single source repository, viz: serving or eventing.
 type Config struct {
-	Buckets       uint32
-	LeaseDuration time.Duration
-	RenewDeadline time.Duration
-	RetryPeriod   time.Duration
+	Buckets                 uint32
+	LeaseDuration           time.Duration
+	RenewDeadline           time.Duration
+	RetryPeriod             time.Duration
+	LeaseNamesPrefixMapping map[string]string
 }
 
 func (c *Config) GetComponentConfig(name string) ComponentConfig {
 	return ComponentConfig{
-		Component:     name,
-		Buckets:       c.Buckets,
-		LeaseDuration: c.LeaseDuration,
-		RenewDeadline: c.RenewDeadline,
-		RetryPeriod:   c.RetryPeriod,
+		Component:               name,
+		Buckets:                 c.Buckets,
+		LeaseDuration:           c.LeaseDuration,
+		RenewDeadline:           c.RenewDeadline,
+		RetryPeriod:             c.RetryPeriod,
+		LeaseNamesPrefixMapping: c.LeaseNamesPrefixMapping,
 	}
 }
 
@@ -123,6 +127,11 @@ type ComponentConfig struct {
 	// be generated to be used as identity for each BuildElector call.
 	// Autoscaler uses the pod IP as identity.
 	Identity string
+
+	// LeaseNamesPrefixMapping maps lease prefixes
+	// from <component>.<package>.<reconciler_type_name> to the
+	// associated value when using standardBuilder.
+	LeaseNamesPrefixMapping map[string]string
 }
 
 // statefulSetID is a envconfig Decodable controller ordinal and name.

--- a/vendor/knative.dev/pkg/leaderelection/context.go
+++ b/vendor/knative.dev/pkg/leaderelection/context.go
@@ -192,7 +192,11 @@ func newStandardBuckets(queueName string, cc ComponentConfig) []reconciler.Bucke
 }
 
 func standardBucketName(ordinal uint32, queueName string, cc ComponentConfig) string {
-	return strings.ToLower(fmt.Sprintf("%s.%s.%02d-of-%02d", cc.Component, queueName, ordinal, cc.Buckets))
+	prefix := fmt.Sprintf("%s.%s", cc.Component, queueName)
+	if v, ok := cc.LeaseNamesPrefixMapping[prefix]; ok && len(v) > 0 {
+		prefix = v
+	}
+	return strings.ToLower(fmt.Sprintf("%s.%02d-of-%02d", prefix, ordinal, cc.Buckets))
 }
 
 type statefulSetBuilder struct {


### PR DESCRIPTION
To actually cherry-pick https://github.com/knative-sandbox/eventing-kafka-broker/commit/3599d8f13b037c450cfa6a07bbb23664c99ca348, we need
some additional patches for knative/pkg.

See individual commits for details.