### PR TITLE
[release-v1.1] Delete service monitors for KafkaSource

### DIFF
--- a/control-plane/cmd/post-install/main.go
+++ b/control-plane/cmd/post-install/main.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	kcs "knative.dev/eventing-kafka/pkg/client/clientset/versioned"
 	"knative.dev/pkg/environment"
+	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
 )
@@ -71,6 +72,14 @@ func run(ctx context.Context) error {
 	}
 	if err := sourceDeleter.Delete(ctx); err != nil {
 		return fmt.Errorf("source migration failed: %w", err)
+	}
+
+	soSourceDeleter := KafkaSourceSoDeleter{
+		dynamic: dynamicclient.Get(ctx),
+		k8s:     kubernetes.NewForConfigOrDie(config),
+	}
+	if err := soSourceDeleter.Delete(ctx); err != nil {
+		return fmt.Errorf("serverless operator deleter failed")
 	}
 
 	return nil

--- a/control-plane/cmd/post-install/so_kafka_source_deleter.go
+++ b/control-plane/cmd/post-install/so_kafka_source_deleter.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/system"
+)
+
+type KafkaSourceSoDeleter struct {
+	dynamic dynamic.Interface
+	k8s     kubernetes.Interface
+}
+
+func (d KafkaSourceSoDeleter) Delete(ctx context.Context) error {
+	smGVR := schema.GroupVersionResource{
+		Group:    "monitoring.coreos.com",
+		Version:  "v1",
+		Resource: "ServiceMonitor",
+	}
+
+	controllerServiceMonitor := "kafka-controller-manager-sm"
+	err := d.dynamic.Resource(smGVR).
+		Namespace(system.Namespace()).
+		Delete(ctx, controllerServiceMonitor, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete service monitor %s/%s: %w", system.Namespace(), controllerServiceMonitor, err)
+	}
+
+	controllerMonitoringService := "kafka-controller-manager-sm-service"
+	err = d.k8s.CoreV1().
+		Services(system.Namespace()).
+		Delete(ctx, controllerMonitoringService, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete service %s/%s: %w", system.Namespace(), controllerMonitoringService, err)
+	}
+
+	return nil
+}

--- a/control-plane/config/post-install/200-controller-cluster-role.yaml
+++ b/control-plane/config/post-install/200-controller-cluster-role.yaml
@@ -65,6 +65,16 @@ rules:
     resourceNames:
       - kafka-source-webhook
       - kafka-controller
+      - kafka-controller-manager-sm-service
+    verbs:
+      - delete
+
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    resourceNames:
+      - kafka-controller-manager-sm
     verbs:
       - delete
 


### PR DESCRIPTION
SO creates dynamically the service and the associated service
monitor to scrape metrics.
This additional logic will make sure these are removed.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>