### PR TITLE
[release-v1.1] Use dynamic client constructor

### DIFF
--- a/control-plane/cmd/post-install/main.go
+++ b/control-plane/cmd/post-install/main.go
@@ -22,10 +22,10 @@ import (
 	"fmt"
 	"log"
 
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	kcs "knative.dev/eventing-kafka/pkg/client/clientset/versioned"
 	"knative.dev/pkg/environment"
-	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
 )
@@ -75,7 +75,7 @@ func run(ctx context.Context) error {
 	}
 
 	soSourceDeleter := KafkaSourceSoDeleter{
-		dynamic: dynamicclient.Get(ctx),
+		dynamic: dynamic.NewForConfigOrDie(config),
 		k8s:     kubernetes.NewForConfigOrDie(config),
 	}
 	if err := soSourceDeleter.Delete(ctx); err != nil {


### PR DESCRIPTION
Got this error since injection isn't enabled:
```
panic: Unable to fetch k8s.io/client-go/dynamic.Interface from context.

goroutine 1 [running]:
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc00028aa80, {0x0, 0x0, 0x0})
	/go/src/knative.dev/eventing-kafka-broker/vendor/go.uber.org/zap/zapcore/entry.go:232 +0x446
go.uber.org/zap.(*SugaredLogger).log(0xc000012010, 0x4, {0x0, 0x0}, {0xc00062fde8, 0xc00062fdf8, 0x11eee5d}, {0x0, 0x0, 0x0})
	/go/src/knative.dev/eventing-kafka-broker/vendor/go.uber.org/zap/sugar.go:227 +0xee
go.uber.org/zap.(*SugaredLogger).Panic(...)
	/go/src/knative.dev/eventing-kafka-broker/vendor/go.uber.org/zap/sugar.go:123
knative.dev/pkg/injection/clients/dynamicclient.Get({0x190cfa8, 0xc000012020})
	/go/src/knative.dev/eventing-kafka-broker/vendor/knative.dev/pkg/injection/clients/dynamicclient/dynamicclient.go:45 +0xd7
main.run({0x190cfa8, 0xc000012020})
	/go/src/knative.dev/eventing-kafka-broker/control-plane/cmd/post-install/main.go:78 +0x24e
main.main()
	/go/src/knative.dev/eventing-kafka-broker/control-plane/cmd/post-install/main.go:46 +0x17d
```

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>