### PR TITLE
Fix resource name servicemonitors

### DIFF
--- a/control-plane/cmd/post-install/so_kafka_source_deleter.go
+++ b/control-plane/cmd/post-install/so_kafka_source_deleter.go
@@ -37,7 +37,7 @@ func (d KafkaSourceSoDeleter) Delete(ctx context.Context) error {
 	smGVR := schema.GroupVersionResource{
 		Group:    "monitoring.coreos.com",
 		Version:  "v1",
-		Resource: "ServiceMonitor",
+		Resource: "servicemonitors",
 	}
 
 	controllerServiceMonitor := "kafka-controller-manager-sm"


### PR DESCRIPTION
We were using the Kind name instead of the resource name.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>