### PR TITLE
[release-v1.3] Remove deletions of comments when resolving YAMLs

### DIFF
--- a/openshift/release/knative-eventing-kafka-broker-cp-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-broker-cp-ci.yaml
@@ -1,5 +1,20 @@
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,6 +28,21 @@ data:
   bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"
 ---
 ---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -23,6 +53,20 @@ metadata:
 data:
   bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"
 ---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -274,8 +318,23 @@ spec:
         service:
           name: kafka-webhook
           namespace: knative-eventing
+
 ---
 ---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -355,6 +414,7 @@ spec:
                       type: object
                       properties:
                         ref:
+                          # TODO add format in description (?)
                           description: |
                             Secret reference.
                           type: object
@@ -436,7 +496,29 @@ spec:
         - name: Reason
           type: string
           jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+#  conversion:
+#    strategy: Webhook
+#    webhook:
+#      conversionReviewVersions: [ "v1alpha1" ]
+#      clientConfig:
+#        service:
+#          name: eventing-kafka-webhook
+#          namespace: knative-eventing
 ---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -460,12 +542,19 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
+          # this is a work around so we don't need to flush out the
+          # schema for each version at this time
+          #
+          # see issue: https://github.com/knative/serving/issues/912
           x-kubernetes-preserve-unknown-fields: true
       subresources:
         status: {}
         scale:
+          # specReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Spec.Replicas.
           specReplicasPath: .spec.consumers
+          # statusReplicasPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Replicas.
           statusReplicasPath: .status.consumers
+          # labelSelectorPath defines the JSONPath inside of a custom resource that corresponds to Scale.Status.Selector
           labelSelectorPath: .status.selector
       additionalPrinterColumns:
         - name: Topics
@@ -500,8 +589,24 @@ spec:
         service:
           name: kafka-source-webhook
           namespace: knative-eventing
+
 ---
 ---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -519,6 +624,20 @@ rules:
       - list
       - watch
 ---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -528,17 +647,44 @@ metadata:
     kafka.eventing.knative.dev/release: v1.3.2
 data:
   _example: |
-                    []
-                  [
-                    {"Name": "RemoveWithEvenPodSpreadPriority",
-                    "Weight": 10,
-                    "Args": "{\"MaxSkew\": 2}"},
-                    {"Name": "RemoveWithAvailabilityZonePriority",
-                    "Weight": 10,
-                    "Args":  "{\"MaxSkew\": 2}"},
-                    {"Name": "RemoveWithHighestOrdinalPriority",
-                    "Weight": 2}
-                  ]
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    #
+    # These predicate plugins are used to filter out pods that
+    # a vreplica cannot be removed from due to not satisfying the
+    # predicate condition. For each pod, the descheduler
+    # will call filter plugins in their configured order.
+    # predicates: |+
+    #                []
+    #
+    # These priority plugins are used to score each pod that
+    # has passed the filtering phase. The scheduler will then
+    # select the pod with the highest weighted score sum to
+    # remove vreplica from. If two pods have an equal score,
+    # a pod is chosen randomly.
+    # priorities: |+
+    #              [
+    #                {"Name": "RemoveWithEvenPodSpreadPriority",
+    #                "Weight": 10,
+    #                "Args": "{\"MaxSkew\": 2}"},
+    #                {"Name": "RemoveWithAvailabilityZonePriority",
+    #                "Weight": 10,
+    #                "Args":  "{\"MaxSkew\": 2}"},
+    #                {"Name": "RemoveWithHighestOrdinalPriority",
+    #                "Weight": 2}
+    #              ]
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -551,14 +697,57 @@ metadata:
     knative.dev/example-checksum: "96896b00"
 data:
   _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # leaseDuration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
     leaseDuration: "15s"
+
+    # renewDeadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
     renewDeadline: "10s"
+
+    # retryPeriod is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
+
+    # buckets is the number of buckets used to partition key space of each
+    # Reconciler. If this number is M and the replica number of the controller
+    # is N, the N replicas will compete for the M buckets. The owner of a
+    # bucket will take care of the reconciling for the keys partitioned into
+    # that bucket.
     buckets: "1"
   leaseDuration: "15s"
   renewDeadline: "10s"
   retryPeriod: "2s"
 ---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -568,6 +757,26 @@ metadata:
     kafka.eventing.knative.dev/release: v1.3.2
 data:
   _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    #
+    # These predicate plugins are used to filter out pods that
+    # a vreplica cannot be placed on due to not satisfying the
+    # predicate condition. For each pod, the scheduler
+    # will call filter plugins in their configured order.
+    # predicates: |+
                   [
                     {"Name": "PodFitsResources"},
                     {"Name": "NoMaxResourceCount",
@@ -575,6 +784,12 @@ data:
                     {"Name": "EvenPodSpread",
                     "Args": "{\"MaxSkew\": 2}"}
                   ]
+    #
+    # These priority plugins are used to score each pod that
+    # has passed the filtering phase. The scheduler will then
+    # select the pod with the highest weighted score sum. If
+    # two pods have an equal score, a pod is chosen randomly.
+    # priorities: |+
                   [
                     {"Name": "AvailabilityZonePriority",
                     "Weight": 10,
@@ -584,6 +799,21 @@ data:
                   ]
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -602,6 +832,20 @@ data:
       </root>
     </configuration>
 ---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -615,12 +859,53 @@ metadata:
     knative.dev/example-checksum: "4002b4c2"
 data:
   _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    #
+    # This may be "zipkin" or "stackdriver", the default is "none"
     backend: "none"
+
+    # URL to zipkin collector where traces are sent.
+    # This must be specified when backend is "zipkin"
     zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+
+    # The GCP project into which stackdriver metrics will be written
+    # when backend is "stackdriver".  If unspecified, the project-id
+    # is read from GCP metadata when running on GCP.
     stackdriver-project-id: "my-project"
+
+    # Enable zipkin debug mode. This allows all spans to be sent to the server
+    # bypassing sampling.
     debug: "false"
+
+    # Percentage (0-1) of requests to trace
     sample-rate: "0.1"
 ---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -628,6 +913,7 @@ metadata:
   labels:
     kafka.eventing.knative.dev/release: v1.3.2
     duck.knative.dev/addressable: "true"
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
   - apiGroups:
       - eventing.knative.dev
@@ -638,6 +924,7 @@ rules:
       - get
       - list
       - watch
+
   - apiGroups:
       - messaging.knative.dev
     resources:
@@ -648,6 +935,20 @@ rules:
       - list
       - watch
 ---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -655,6 +956,7 @@ metadata:
   labels:
     kafka.eventing.knative.dev/release: v1.3.2
     duck.knative.dev/channelable: "true"
+# Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
   - apiGroups:
       - messaging.knative.dev
@@ -669,8 +971,24 @@ rules:
       - update
       - patch
       - delete
+
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -716,6 +1034,7 @@ rules:
       - delete
       - patch
       - watch
+
   - apiGroups:
       - "*"
     resources:
@@ -724,6 +1043,8 @@ rules:
       - list
       - get
       - watch
+
+  # Scheduler permissions
   - apiGroups:
       - "*"
     resources:
@@ -743,6 +1064,8 @@ rules:
       - watch
       - update
       - patch
+
+  # Internal APIs
   - apiGroups:
       - "internal.kafka.eventing.knative.dev"
     resources:
@@ -766,6 +1089,7 @@ rules:
     verbs:
       - update
       - delete
+  # Eventing resources and statuses we care about
   - apiGroups:
       - "eventing.knative.dev"
     resources:
@@ -781,6 +1105,8 @@ rules:
       - watch
       - patch
       - update
+
+  # eventing.knative.dev resources and finalizers we care about.
   - apiGroups:
       - "eventing.knative.dev"
     resources:
@@ -789,6 +1115,8 @@ rules:
       - "kafkasinks/finalizers"
     verbs:
       - update
+
+  # messaging.knative.dev resources and finalizers we care about.
   - apiGroups:
       - messaging.knative.dev
     resources:
@@ -815,6 +1143,8 @@ rules:
       - kafkachannels/finalizers
     verbs:
       - update
+
+  # sources.knative.dev resources and finalizers we care about.
   - apiGroups:
       - sources.knative.dev
     resources:
@@ -834,6 +1164,21 @@ rules:
       - update
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -843,6 +1188,21 @@ metadata:
     kafka.eventing.knative.dev/release: v1.3.2
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -857,6 +1217,7 @@ roleRef:
   kind: ClusterRole
   name: kafka-controller
   apiGroup: rbac.authorization.k8s.io
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -874,6 +1235,21 @@ roleRef:
   name: addressable-resolver
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -896,6 +1272,8 @@ spec:
       securityContext:
         runAsNonRoot: true
       serviceAccountName: kafka-controller
+
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -905,6 +1283,7 @@ spec:
                     app: kafka-controller
                 topologyKey: kubernetes.io/hostname
               weight: 100
+
       containers:
         - name: controller
           image: registry.ci.openshift.org/openshift/knative-v1.3.2:knative-eventing-kafka-broker-kafka-controller
@@ -918,6 +1297,7 @@ spec:
               value: knative-eventing
             - name: SOURCE_DATA_PLANE_CONFIG_MAP_NAMESPACE
               value: knative-eventing
+
             - name: BROKER_DATA_PLANE_CONFIG_MAP_NAME
               value: kafka-broker-brokers-triggers
             - name: CHANNEL_DATA_PLANE_CONFIG_MAP_NAME
@@ -926,6 +1306,7 @@ spec:
               value: kafka-sink-sinks
             - name: SOURCE_DATA_PLANE_CONFIG_MAP_NAME
               value: kafka-source-sources
+
             - name: BROKER_DATA_PLANE_CONFIG_FORMAT
               value: json
             - name: CHANNEL_DATA_PLANE_CONFIG_FORMAT
@@ -934,6 +1315,7 @@ spec:
               value: json
             - name: SOURCE_DATA_PLANE_CONFIG_FORMAT
               value: json
+
             - name: BROKER_INGRESS_NAME
               value: kafka-broker-ingress
             - name: CHANNEL_INGRESS_NAME
@@ -942,6 +1324,7 @@ spec:
               value: kafka-sink-ingress
             - name: SOURCE_INGRESS_NAME
               value: kafka-source-ingress
+
             - name: BROKER_GENERAL_CONFIG_MAP_NAME
               value: kafka-broker-config
             - name: CHANNEL_GENERAL_CONFIG_MAP_NAME
@@ -950,12 +1333,14 @@ spec:
               value: kafka-broker-config
             - name: SOURCE_GENERAL_CONFIG_MAP_NAME
               value: kafka-broker-config
+
             - name: BROKER_INGRESS_POD_PORT
               value: "8080"
             - name: CHANNEL_INGRESS_POD_PORT
               value: "8080"
             - name: SINK_INGRESS_POD_PORT
               value: "8080"
+
             - name: BROKER_SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -972,12 +1357,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+
             - name: BROKER_DEFAULT_BACKOFF_DELAY_MS
               value: "1000" # 1 second
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+
             - name: CONFIG_LEADERELECTION_NAME
               value: config-kafka-leader-election
             - name: CONFIG_LOGGING_NAME
@@ -1002,6 +1389,21 @@ spec:
       restartPolicy: Always
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -1009,6 +1411,7 @@ metadata:
   labels:
     kafka.eventing.knative.dev/release: v1.3.2
 rules:
+  # For watching logging configuration and getting certs.
   - apiGroups:
       - ""
     resources:
@@ -1017,6 +1420,8 @@ rules:
       - "get"
       - "list"
       - "watch"
+
+  # For manipulating certs into secrets.
   - apiGroups:
       - ""
     resources:
@@ -1029,18 +1434,23 @@ rules:
       - "list"
       - "watch"
       - "patch"
+
+  # For getting our Deployment so we can decorate with ownerref.
   - apiGroups:
       - "apps"
     resources:
       - "deployments"
     verbs:
       - "get"
+
   - apiGroups:
       - "apps"
     resources:
       - "deployments/finalizers"
     verbs:
       - update
+
+  # For actually registering our webhook.
   - apiGroups:
       - "admissionregistration.k8s.io"
     resources:
@@ -1054,17 +1464,23 @@ rules:
       - "delete"
       - "patch"
       - "watch"
+
+  # For leader election
   - apiGroups:
       - "coordination.k8s.io"
     resources:
       - "leases"
     verbs: *everything
+
+  # finalizers are needed for the owner reference of the webhook
   - apiGroups:
       - ""
     resources:
       - "namespaces/finalizers"
     verbs:
       - "update"
+
+  # Eventing resources care about
   - apiGroups:
       - "eventing.knative.dev"
     resources:
@@ -1073,6 +1489,8 @@ rules:
       - list
       - get
       - watch
+
+  # messaging.knative.dev resources and finalizers we care about.
   - apiGroups:
       - messaging.knative.dev
     resources:
@@ -1082,6 +1500,21 @@ rules:
       - list
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -1091,6 +1524,21 @@ metadata:
     kafka.eventing.knative.dev/release: v1.3.2
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -1105,7 +1553,22 @@ roleRef:
   kind: ClusterRole
   name: kafka-webhook-eventing
   apiGroup: rbac.authorization.k8s.io
+
 ---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -1123,6 +1586,20 @@ webhooks:
     name: defaulting.webhook.kafka.eventing.knative.dev
     timeoutSeconds: 2
 ---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -1130,6 +1607,7 @@ metadata:
   labels:
     kafka.eventing.knative.dev/release: v1.3.2
 webhooks:
+  # Dispatcher pods webhook config.
   - admissionReviewVersions: [ "v1", "v1beta1" ]
     clientConfig:
       service:
@@ -1149,6 +1627,20 @@ webhooks:
       matchLabels:
         app.kubernetes.io/component: kafka-dispatcher
 ---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -1156,7 +1648,22 @@ metadata:
   namespace: knative-eventing
   labels:
     kafka.eventing.knative.dev/release: v1.3.2
+# The data is populated at install time.
 ---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -1174,6 +1681,20 @@ webhooks:
     name: validation.webhook.kafka.eventing.knative.dev
     timeoutSeconds: 2
 ---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1192,6 +1713,7 @@ spec:
         app: kafka-webhook-eventing
         kafka.eventing.knative.dev/release: v1.3.2
     spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -1201,13 +1723,17 @@ spec:
                     app: kafka-webhook-eventing
                 topologyKey: kubernetes.io/hostname
               weight: 100
+
       serviceAccountName: kafka-webhook-eventing
       securityContext:
         runAsNonRoot: true
+
       containers:
         - name: kafka-webhook-eventing
           terminationMessagePolicy: FallbackToLogsOnError
+
           image: registry.ci.openshift.org/openshift/knative-v1.3.2:knative-eventing-kafka-broker-webhook-kafka
+
           resources:
             requests:
               cpu: 20m
@@ -1215,6 +1741,7 @@ spec:
             limits:
               cpu: 200m
               memory: 200Mi
+
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -1234,8 +1761,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+
           securityContext:
             allowPrivilegeEscalation: false
+
           ports:
             - name: https-webhook
               containerPort: 8443
@@ -1243,6 +1772,7 @@ spec:
               containerPort: 9090
             - name: profiling
               containerPort: 8008
+
           readinessProbe: &probe
             periodSeconds: 1
             httpGet:
@@ -1254,7 +1784,11 @@ spec:
           livenessProbe:
             <<: *probe
             initialDelaySeconds: 20
+
+      # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
+      # high value that we respect whatever value it has configured for the lame duck grace period.
       terminationGracePeriodSeconds: 300
+
 ---
 apiVersion: v1
 kind: Service

--- a/openshift/release/knative-eventing-kafka-broker-dp-ci.yaml
+++ b/openshift/release/knative-eventing-kafka-broker-dp-ci.yaml
@@ -1,5 +1,20 @@
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,6 +28,7 @@ data:
     value.serializer=io.cloudevents.kafka.CloudEventSerializer
     acks=all
     buffer.memory=33554432
+    # compression.type=snappy
     retries=2147483647
     batch.size=16384
     client.dns.lookup=use_all_dns_ips
@@ -27,12 +43,15 @@ data:
     enable.idempotence=false
     max.in.flight.requests.per.connection=5
     metadata.max.age.ms=300000
+    # metric.reporters=""
     metrics.num.samples=2
     metrics.recording.level=INFO
     metrics.sample.window.ms=30000
     reconnect.backoff.max.ms=1000
     reconnect.backoff.ms=50
     retry.backoff.ms=100
+    # transaction.timeout.ms=60000
+    # transactional.id=null
   config-kafka-broker-consumer.properties: |
     key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
     value.deserializer=io.cloudevents.kafka.CloudEventDeserializer
@@ -40,6 +59,11 @@ data:
     heartbeat.interval.ms=3000
     max.partition.fetch.bytes=1048576
     session.timeout.ms=10000
+    # ssl.key.password=
+    # ssl.keystore.location=
+    # ssl.keystore.password=
+    # ssl.truststore.location=
+    # ssl.truststore.password=
     allow.auto.create.topics=true
     auto.offset.reset=earliest
     client.dns.lookup=use_all_dns_ips
@@ -51,22 +75,67 @@ data:
     isolation.level=read_uncommitted
     max.poll.interval.ms=300000
     max.poll.records=500
+    # partition.assignment.strategy=org.apache.kafka.clients.consumer.CooperativeStickyAssignor
     receive.buffer.bytes=65536
     request.timeout.ms=30000
+    # sasl.client.callback.handler.class=
+    # sasl.jaas.config=
+    # sasl.kerberos.service.name=
+    # sasl.login.callback.handler.class
+    # sasl.login.class
+    # sasl.mechanism
     security.protocol=PLAINTEXT
     send.buffer.bytes=131072
+    # ssl.enabled.protocols=
+    # ssl.keystore.type=
+    # ssl.protocol=
+    # ssl.provider=
     auto.commit.interval.ms=5000
     check.crcs=true
+    # client.rack=
     fetch.max.wait.ms=500
+    # interceptor.classes=
     metadata.max.age.ms=600000
+    # metrics.reporters=
+    # metrics.num.samples=
+    # metrics.recording.level=INFO
+    # metrics.sample.window.ms=
     reconnect.backoff.max.ms=1000
     retry.backoff.ms=100
+    # sasl.kerberos.kinit.cmd=
+    # sasl.kerberos.min.time.before.relogin=
+    # sasl.kerberos.ticket.renew.jitter=
+    # sasl.login.refresh.buffer.seconds=
+    # sasl.login.refresh.min.period.seconds=
+    # sasl.login.refresh.window.factor
+    # sasl.login.refresh.window.jitter
+    # security.providers
+    # ssl.cipher.suites
+    # ssl.endpoint.identification.algorithm
+    # ssl.keymanager.algorithm
+    # ssl.secure.random.implementation
+    # ssl.trustmanager.algorithm
   config-kafka-broker-webclient.properties: |
     idleTimeout=10000
   config-kafka-broker-httpserver.properties: |
     idleTimeout=0
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -84,6 +153,21 @@ rules:
       - watch
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -93,6 +177,21 @@ metadata:
     kafka.eventing.knative.dev/release: v1.3.2
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -109,6 +208,21 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -185,8 +299,10 @@ spec:
               value: "false"
             - name: CONFIG_TRACING_PATH
               value: "/etc/tracing"
+            # https://github.com/fabric8io/kubernetes-client/issues/2212
             - name: HTTP2_DISABLE
               value: "true"
+            # This should be set according to initial delay seconds
             - name: WAIT_STARTUP_SECONDS
               value: "8"
           command:
@@ -195,6 +311,7 @@ spec:
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"
+          # TODO set resources (limits and requests)
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -242,6 +359,21 @@ spec:
           - name: single-request-reopen
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -264,6 +396,7 @@ spec:
       serviceAccountName: knative-kafka-broker-data-plane
       securityContext:
         runAsNonRoot: true
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -328,8 +461,10 @@ spec:
               value: "false"
             - name: CONFIG_TRACING_PATH
               value: "/etc/tracing"
+            # https://github.com/fabric8io/kubernetes-client/issues/2212
             - name: HTTP2_DISABLE
               value: "true"
+            # This should be set according to initial delay seconds
             - name: WAIT_STARTUP_SECONDS
               value: "8"
           command:
@@ -338,6 +473,7 @@ spec:
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"
+          # TODO set resources (limits and requests)
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -381,6 +517,7 @@ spec:
             name: config-tracing
       restartPolicy: Always
 ---
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -404,6 +541,21 @@ spec:
 ---
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -417,6 +569,7 @@ data:
     value.serializer=io.cloudevents.kafka.CloudEventSerializer
     acks=all
     buffer.memory=33554432
+    # compression.type=snappy
     retries=2147483647
     batch.size=16384
     client.dns.lookup=use_all_dns_ips
@@ -431,16 +584,34 @@ data:
     enable.idempotence=false
     max.in.flight.requests.per.connection=5
     metadata.max.age.ms=300000
+    # metric.reporters=""
     metrics.num.samples=2
     metrics.recording.level=INFO
     metrics.sample.window.ms=30000
     reconnect.backoff.max.ms=1000
     reconnect.backoff.ms=50
     retry.backoff.ms=100
+    # transaction.timeout.ms=60000
+    # transactional.id=null
   config-kafka-sink-httpserver.properties: |
     idleTimeout=0
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -458,6 +629,21 @@ rules:
       - watch
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -467,6 +653,21 @@ metadata:
     kafka.eventing.knative.dev/release: v1.3.2
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -483,6 +684,21 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 ---
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -505,6 +721,7 @@ spec:
       serviceAccountName: knative-kafka-sink-data-plane
       securityContext:
         runAsNonRoot: true
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -569,8 +786,10 @@ spec:
               value: "false"
             - name: CONFIG_TRACING_PATH
               value: "/etc/tracing"
+            # https://github.com/fabric8io/kubernetes-client/issues/2212
             - name: HTTP2_DISABLE
               value: "true"
+            # This should be set according to initial delay seconds
             - name: WAIT_STARTUP_SECONDS
               value: "8"
           command:
@@ -579,6 +798,7 @@ spec:
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"
+          # TODO set resources (limits and requests)
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -622,6 +842,7 @@ spec:
             name: config-tracing
       restartPolicy: Always
 ---
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -645,6 +866,21 @@ spec:
 ---
 ---
 ---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -658,6 +894,7 @@ data:
     value.serializer=io.cloudevents.kafka.CloudEventSerializer
     acks=all
     buffer.memory=33554432
+    # compression.type=snappy
     retries=2147483647
     batch.size=16384
     client.dns.lookup=use_all_dns_ips
@@ -672,12 +909,15 @@ data:
     enable.idempotence=false
     max.in.flight.requests.per.connection=5
     metadata.max.age.ms=300000
+    # metric.reporters=""
     metrics.num.samples=2
     metrics.recording.level=INFO
     metrics.sample.window.ms=30000
     reconnect.backoff.max.ms=1000
     reconnect.backoff.ms=50
     retry.backoff.ms=100
+    # transaction.timeout.ms=60000
+    # transactional.id=null
   config-kafka-source-consumer.properties: |
     cloudevent.invalid.transformer.enabled=true
     cloudevent.invalid.kind.plural=kafkasources
@@ -687,6 +927,11 @@ data:
     heartbeat.interval.ms=3000
     max.partition.fetch.bytes=1048576
     session.timeout.ms=10000
+    # ssl.key.password=
+    # ssl.keystore.location=
+    # ssl.keystore.password=
+    # ssl.truststore.location=
+    # ssl.truststore.password=
     allow.auto.create.topics=true
     auto.offset.reset=earliest
     client.dns.lookup=use_all_dns_ips
@@ -698,20 +943,65 @@ data:
     isolation.level=read_uncommitted
     max.poll.interval.ms=300000
     max.poll.records=500
+    # partition.assignment.strategy=org.apache.kafka.clients.consumer.CooperativeStickyAssignor
     receive.buffer.bytes=65536
     request.timeout.ms=30000
+    # sasl.client.callback.handler.class=
+    # sasl.jaas.config=
+    # sasl.kerberos.service.name=
+    # sasl.login.callback.handler.class
+    # sasl.login.class
+    # sasl.mechanism
     security.protocol=PLAINTEXT
     send.buffer.bytes=131072
+    # ssl.enabled.protocols=
+    # ssl.keystore.type=
+    # ssl.protocol=
+    # ssl.provider=
     auto.commit.interval.ms=5000
     check.crcs=true
+    # client.rack=
     fetch.max.wait.ms=500
+    # interceptor.classes=
     metadata.max.age.ms=600000
+    # metrics.reporters=
+    # metrics.num.samples=
+    # metrics.recording.level=INFO
+    # metrics.sample.window.ms=
     reconnect.backoff.max.ms=1000
     retry.backoff.ms=100
+    # sasl.kerberos.kinit.cmd=
+    # sasl.kerberos.min.time.before.relogin=
+    # sasl.kerberos.ticket.renew.jitter=
+    # sasl.login.refresh.buffer.seconds=
+    # sasl.login.refresh.min.period.seconds=
+    # sasl.login.refresh.window.factor
+    # sasl.login.refresh.window.jitter
+    # security.providers
+    # ssl.cipher.suites
+    # ssl.endpoint.identification.algorithm
+    # ssl.keymanager.algorithm
+    # ssl.secure.random.implementation
+    # ssl.trustmanager.algorithm
   config-kafka-source-webclient.properties: |
     idleTimeout=10000
 ---
 ---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -729,6 +1019,21 @@ rules:
       - watch
 ---
 ---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -738,6 +1043,21 @@ metadata:
     kafka.eventing.knative.dev/release: v1.3.2
 ---
 ---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -754,6 +1074,21 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 ---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -830,8 +1165,10 @@ spec:
               value: "false"
             - name: CONFIG_TRACING_PATH
               value: "/etc/tracing"
+            # https://github.com/fabric8io/kubernetes-client/issues/2212
             - name: HTTP2_DISABLE
               value: "true"
+            # This should be set according to initial delay seconds
             - name: WAIT_STARTUP_SECONDS
               value: "8"
           command:
@@ -840,6 +1177,7 @@ spec:
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"
+          # TODO set resources (limits and requests)
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -887,6 +1225,21 @@ spec:
           - name: single-request-reopen
 ---
 ---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -900,6 +1253,7 @@ data:
     value.serializer=io.cloudevents.kafka.CloudEventSerializer
     acks=all
     buffer.memory=33554432
+    # compression.type=snappy
     retries=2147483647
     batch.size=16384
     client.dns.lookup=use_all_dns_ips
@@ -914,12 +1268,15 @@ data:
     enable.idempotence=false
     max.in.flight.requests.per.connection=5
     metadata.max.age.ms=300000
+    # metric.reporters=""
     metrics.num.samples=2
     metrics.recording.level=INFO
     metrics.sample.window.ms=30000
     reconnect.backoff.max.ms=1000
     reconnect.backoff.ms=50
     retry.backoff.ms=100
+    # transaction.timeout.ms=60000
+    # transactional.id=null
   config-kafka-channel-consumer.properties: |
     key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
     value.deserializer=io.cloudevents.kafka.CloudEventDeserializer
@@ -927,6 +1284,11 @@ data:
     heartbeat.interval.ms=3000
     max.partition.fetch.bytes=1048576
     session.timeout.ms=10000
+    # ssl.key.password=
+    # ssl.keystore.location=
+    # ssl.keystore.password=
+    # ssl.truststore.location=
+    # ssl.truststore.password=
     allow.auto.create.topics=true
     auto.offset.reset=earliest
     client.dns.lookup=use_all_dns_ips
@@ -938,22 +1300,67 @@ data:
     isolation.level=read_uncommitted
     max.poll.interval.ms=300000
     max.poll.records=500
+    # partition.assignment.strategy=org.apache.kafka.clients.consumer.CooperativeStickyAssignor
     receive.buffer.bytes=65536
     request.timeout.ms=30000
+    # sasl.client.callback.handler.class=
+    # sasl.jaas.config=
+    # sasl.kerberos.service.name=
+    # sasl.login.callback.handler.class
+    # sasl.login.class
+    # sasl.mechanism
     security.protocol=PLAINTEXT
     send.buffer.bytes=131072
+    # ssl.enabled.protocols=
+    # ssl.keystore.type=
+    # ssl.protocol=
+    # ssl.provider=
     auto.commit.interval.ms=5000
     check.crcs=true
+    # client.rack=
     fetch.max.wait.ms=500
+    # interceptor.classes=
     metadata.max.age.ms=600000
+    # metrics.reporters=
+    # metrics.num.samples=
+    # metrics.recording.level=INFO
+    # metrics.sample.window.ms=
     reconnect.backoff.max.ms=1000
     retry.backoff.ms=100
+    # sasl.kerberos.kinit.cmd=
+    # sasl.kerberos.min.time.before.relogin=
+    # sasl.kerberos.ticket.renew.jitter=
+    # sasl.login.refresh.buffer.seconds=
+    # sasl.login.refresh.min.period.seconds=
+    # sasl.login.refresh.window.factor
+    # sasl.login.refresh.window.jitter
+    # security.providers
+    # ssl.cipher.suites
+    # ssl.endpoint.identification.algorithm
+    # ssl.keymanager.algorithm
+    # ssl.secure.random.implementation
+    # ssl.trustmanager.algorithm
   config-kafka-channel-webclient.properties: |
     idleTimeout=10000
   config-kafka-channel-httpserver.properties: |
     idleTimeout=0
 ---
 ---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -971,6 +1378,21 @@ rules:
       - watch
 ---
 ---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -980,6 +1402,21 @@ metadata:
     kafka.eventing.knative.dev/release: v1.3.2
 ---
 ---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -996,6 +1433,21 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 ---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1072,8 +1524,10 @@ spec:
               value: "false"
             - name: CONFIG_TRACING_PATH
               value: "/etc/tracing"
+            # https://github.com/fabric8io/kubernetes-client/issues/2212
             - name: HTTP2_DISABLE
               value: "true"
+            # This should be set according to initial delay seconds
             - name: WAIT_STARTUP_SECONDS
               value: "8"
           command:
@@ -1082,6 +1536,7 @@ spec:
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"
+          # TODO set resources (limits and requests)
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -1129,6 +1584,21 @@ spec:
           - name: single-request-reopen
 ---
 ---
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1151,6 +1621,7 @@ spec:
       serviceAccountName: knative-kafka-channel-data-plane
       securityContext:
         runAsNonRoot: true
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -1215,8 +1686,10 @@ spec:
               value: "false"
             - name: CONFIG_TRACING_PATH
               value: "/etc/tracing"
+            # https://github.com/fabric8io/kubernetes-client/issues/2212
             - name: HTTP2_DISABLE
               value: "true"
+            # This should be set according to initial delay seconds
             - name: WAIT_STARTUP_SECONDS
               value: "8"
           command:
@@ -1225,6 +1698,7 @@ spec:
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
             - "-jar"
             - "/app/app.jar"
+          # TODO set resources (limits and requests)
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -1268,6 +1742,7 @@ spec:
             name: config-tracing
       restartPolicy: Always
 ---
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -24,8 +24,6 @@ function resolve_resources() {
       -e "s+\${KNATIVE_KAFKA_DISPATCHER_IMAGE}+${image_prefix}broker-dispatcher${image_tag}+" \
       -e "s+\${KNATIVE_KAFKA_RECEIVER_IMAGE}+${image_prefix}broker-receiver${image_tag}+" \
       -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}broker-\4${image_tag}+g" \
-      -e '/^[ \t]*#/d' \
-      -e '/^[ \t]*$/d' \
       "$yaml" >>$resolved_file_name
   done
 }


### PR DESCRIPTION
By removing lines starting with `#`, we produce invalid YAMLs.

I think it's reasonable to keep them because in this midstream
repository we just need something that we can apply.

I don't know the reason of removing comments, so if you have more
insights, I'd be happy to discuss them.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>