### PR TITLE
[release-v1.1] Skip Consumer records that are not CloudEvents (#2072)

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
@@ -77,6 +77,12 @@ public class Metrics {
    */
   public static final String EVENT_PROCESSING_LATENCY = "event_processing_latencies";
 
+    /**
+   * @link https://knative.dev/docs/eventing/observability/metrics/eventing-metrics/
+   * @see Metrics#discardedEventCount(io.micrometer.core.instrument.Tags)
+   */
+  public static final String DISCARDED_EVENTS_COUNT = "discarded_invalid_event_count";
+
   /**
    * @link https://knative.dev/docs/eventing/observability/metrics/eventing-metrics/
    */
@@ -212,5 +218,13 @@ public class Metrics {
       .tags(tags)
       .baseUnit(BaseUnits.MILLISECONDS)
       .serviceLevelObjectives(LATENCY_SLOs);
+  }
+
+  public static Counter.Builder discardedEventCount(final io.micrometer.core.instrument.Tags tags) {
+    return Counter
+      .builder(DISCARDED_EVENTS_COUNT)
+      .description("Number of invalid events discarded")
+      .tags(tags)
+      .baseUnit(Metrics.Units.DIMENSIONLESS);
   }
 }

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/InvalidCloudEvent.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/InvalidCloudEvent.java
@@ -28,11 +28,11 @@ import java.util.Set;
  * <p>
  * See {@link InvalidCloudEventInterceptor} and {@link CloudEventDeserializer} for more details.
  */
-class InvalidCloudEvent implements CloudEvent {
+public class InvalidCloudEvent implements CloudEvent {
 
   private final byte[] data;
 
-  InvalidCloudEvent(byte[] data) {
+  public InvalidCloudEvent(byte[] data) {
     this.data = data;
   }
 

--- a/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventDeserializerTest.java
+++ b/data-plane/dispatcher/src/test/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/CloudEventDeserializerTest.java
@@ -76,7 +76,7 @@ public class CloudEventDeserializerTest {
   }
 
   @Test
-  public void shouldDeserializeInvalidCloudEventWhenEnabled() {
+  public void shouldDeserializeInvalidCloudEvent() {
     final var topic = "test";
 
     final var headers = new RecordHeaders()
@@ -84,46 +84,26 @@ public class CloudEventDeserializerTest {
 
     final var deserializer = new CloudEventDeserializer();
     final var configs = new HashMap<String, String>();
-    configs.put(CloudEventDeserializer.INVALID_CE_WRAPPER_ENABLED, "true");
     deserializer.configure(configs, false);
 
     final var event = deserializer.deserialize(topic, headers, new byte[]{1, 4});
-
-    assertThat(event).isInstanceOf(InvalidCloudEvent.class);
 
     assertThat(event).isInstanceOf(InvalidCloudEvent.class);
     assertOnInvalidCloudEvent((InvalidCloudEvent) event);
   }
 
   @Test
-  public void shouldDeserializeInvalidCloudWithoutHeadersEventWhenEnabled() {
+  public void shouldDeserializeInvalidCloudWithoutHeadersEvent() {
     final var topic = "test";
 
     final var deserializer = new CloudEventDeserializer();
     final var configs = new HashMap<String, String>();
-    configs.put(CloudEventDeserializer.INVALID_CE_WRAPPER_ENABLED, "true");
     deserializer.configure(configs, false);
 
     final var event = deserializer.deserialize(topic, new byte[]{1, 4});
 
     assertThat(event).isInstanceOf(InvalidCloudEvent.class);
     assertOnInvalidCloudEvent((InvalidCloudEvent) event);
-  }
-
-  @Test
-  public void shouldNotDeserializeInvalidCloudEventWhenDisabled() {
-    final var topic = "test";
-
-    final var headers = new RecordHeaders()
-      .add(new RecordHeader("knative", "knative".getBytes(StandardCharsets.UTF_8)));
-
-    final var deserializer = new CloudEventDeserializer();
-
-    final var configs = new HashMap<String, String>();
-    deserializer.configure(configs, false);
-
-    assertThatThrownBy(() -> deserializer.deserialize(topic, headers, new byte[]{1, 4}));
-    assertThatThrownBy(() -> deserializer.deserialize(topic, new byte[]{1, 4}));
   }
 
   private void assertOnInvalidCloudEvent(InvalidCloudEvent invalid) {


### PR DESCRIPTION
Cherry-pick of https://github.com/knative-sandbox/eventing-kafka-broker/commit/5ca60b009fc14da76a7a35554bfa56a9be765959

* Skip Consumer records that are not CloudEvents

Signed-off-by: aavarghese <avarghese@us.ibm.com>

* Update description for new metric

Co-authored-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>

* Update string value for new metric

Co-authored-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>

* Review updates

Signed-off-by: aavarghese <avarghese@us.ibm.com>

Co-authored-by: aavarghese <avarghese@us.ibm.com>
Co-authored-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>