### PR TITLE
[release-v1.1] Increase default timeout to 10 minutes (#2057)

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleFactoryImpl.java
@@ -79,6 +79,8 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
 
   private static final Logger logger = LoggerFactory.getLogger(ConsumerVerticleFactoryImpl.class);
 
+  private static final long DEFAULT_TIMEOUT_MS = 600_000L;
+
   private final static CloudEventSender NO_DEAD_LETTER_SINK_SENDER = CloudEventSender.noop("No dead letter sink set");
 
   private final Map<String, Object> consumerConfigs;
@@ -282,7 +284,7 @@ public class ConsumerVerticleFactoryImpl implements ConsumerVerticleFactory {
       options.setTimeout(
         egressConfig.getTimeout() > 0 ?
           egressConfig.getTimeout() :
-          CircuitBreakerOptions.DEFAULT_TIMEOUT
+          DEFAULT_TIMEOUT_MS
       );
 
       // Retry options


### PR DESCRIPTION
As discussed previously, the default timeout of 10 seconds isn't
sometimes enough to even start a Knative Service.

Using 10 minutes will avoid overriding the timeout with
`spec.delivery.timeout` in most of the use cases.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>