### PR TITLE
[SRVKE-1202] Remove KafkaBinding's podspecable ClusterRoleBinding

### DIFF
--- a/control-plane/cmd/post-install/kafka_source_deleter.go
+++ b/control-plane/cmd/post-install/kafka_source_deleter.go
@@ -109,6 +109,15 @@ func (d *kafkaSourceDeleter) Delete(ctx context.Context) error {
 		return fmt.Errorf("failed to delete ClusterRoleBinding %s: %w", kafkaControllerAddressableResolverClusterRoleBinding, err)
 	}
 
+	const kafkaBindingClusterRoleBinding = "eventing-sources-kafka-controller-podspecable-binding"
+	err = d.k8s.
+		RbacV1().
+		ClusterRoleBindings().
+		Delete(ctx, kafkaBindingClusterRoleBinding, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete ClusterRoleBinding %s: %w", kafkaBindingClusterRoleBinding, err)
+	}
+
 	const kafkaControllerClusterRole = "eventing-sources-kafka-controller"
 	err = d.k8s.
 		RbacV1().

--- a/control-plane/config/post-install/200-controller-cluster-role.yaml
+++ b/control-plane/config/post-install/200-controller-cluster-role.yaml
@@ -94,6 +94,7 @@ rules:
     resourceNames:
       - eventing-sources-kafka-controller
       - eventing-sources-kafka-controller-addressable-resolver
+      - eventing-sources-kafka-controller-podspecable-binding
     verbs:
       - delete
   - apiGroups:


### PR DESCRIPTION
The new `KafkaSource` doesn't support `KafkaBinding` so this
`ClusterRoleBinding` can be removed as part of the migration.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>