### PR TITLE
[release-v1.1] Limit the number of poll calls for unordered delivery (#2095)

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/UnorderedConsumerVerticle.java
@@ -38,12 +38,13 @@ public final class UnorderedConsumerVerticle extends BaseConsumerVerticle {
   private static final long BACKOFF_DELAY_MS = 200;
   // This shouldn't be more than 2000, which is the default max time allowed
   // to block a verticle thread.
-  private static final Duration POLL_TIMEOUT = Duration.ofMillis(1000);
+  private static final Duration POLL_TIMEOUT = Duration.ofMillis(500);
 
   private final int maxPollRecords;
 
-  private boolean stopPolling;
+  private boolean closed;
   private int inFlightRecords;
+  private boolean isPollInFlight;
 
   public UnorderedConsumerVerticle(final Initializer initializer,
                                    final Set<String> topics,
@@ -55,7 +56,8 @@ public final class UnorderedConsumerVerticle extends BaseConsumerVerticle {
       this.maxPollRecords = maxPollRecords;
     }
     this.inFlightRecords = 0;
-    this.stopPolling = false;
+    this.closed = false;
+    this.isPollInFlight = false;
   }
 
   @Override
@@ -80,23 +82,25 @@ public final class UnorderedConsumerVerticle extends BaseConsumerVerticle {
    * control the memory consumption of the dispatcher.
    */
   private synchronized void poll() {
-    if (stopPolling) {
+    if (closed || isPollInFlight) {
       return;
     }
     if (inFlightRecords >= maxPollRecords) {
       logger.info(
         "In flight records exceeds " + ConsumerConfig.MAX_POLL_RECORDS_CONFIG +
-          " waiting for response from subscriber before polling for new records {} {}",
+          " waiting for response from subscriber before polling for new records {} {} {}",
         keyValue(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords),
-        keyValue("records", inFlightRecords)
+        keyValue("records", inFlightRecords),
+        keyValue("topics", topics)
       );
       return;
     }
-
+    isPollInFlight = true;
     this.consumer
       .poll(POLL_TIMEOUT)
       .onSuccess(this::handleRecords)
       .onFailure(cause -> {
+        isPollInFlight = false;
         logger.error("Failed to poll messages {}", keyValue("topics", topics), cause);
         // Wait before retrying.
         vertx.setTimer(BACKOFF_DELAY_MS, t -> poll());
@@ -104,11 +108,18 @@ public final class UnorderedConsumerVerticle extends BaseConsumerVerticle {
   }
 
   private void handleRecords(final KafkaConsumerRecords<Object, CloudEvent> records) {
+    if (closed) {
+      isPollInFlight = false;
+      return;
+    }
+
     // We are not forcing the dispatcher to send less than `max.poll.records`
     // requests because we don't want to keep records in-memory by waiting
     // for responses.
+    this.inFlightRecords += records.size();
+    isPollInFlight = false;
+
     for (int i = 0; i < records.size(); i++) {
-      this.inFlightRecords++;
       this.recordDispatcher.dispatch(records.recordAt(i))
         .onComplete(v -> {
           this.inFlightRecords--;
@@ -120,7 +131,7 @@ public final class UnorderedConsumerVerticle extends BaseConsumerVerticle {
 
   @Override
   public void stop(Promise<Void> stopPromise) {
-    this.stopPolling = true;
+    this.closed = true;
     // Stop the consumer
     super.stop(stopPromise);
   }


### PR DESCRIPTION
Cherry-pick of https://github.com/knative-sandbox/eventing-kafka-broker/commit/dcb1a6e5044981daa485c2c07c85b2f1c269ec6c

* Limit the number of poll calls for unordered delivery

Multiple async `poll` calls can lead to a large number of records
loaded into memory and dispatched to subscribers.

In this PR, I'm limiting the number of poll requests to 1.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>