### PR TITLE
[release-v1.2] Execute new e2e test suite on OCP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ test-conformance:
 	sh openshift/e2e-conformance-tests.sh
 .PHONY: test-conformance
 
+test-reconciler:
+	sh openshift/e2e-rekt-tests.sh
+.PHONY: test-reconciler
+
 # Requires ko 0.2.0 or newer.
 test-images:
 	for img in $(TEST_IMAGES); do \

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -85,7 +85,8 @@ function install_serverless() {
   unset OPENSHIFT_CI
   pushd $operator_dir
 
-  ./hack/install.sh && header "Serverless Operator installed successfully" || failed=1
+  # We want just eventing
+  INSTALL_SERVING="false" ENABLE_TRACING="true" ./hack/install.sh && header "Serverless Operator installed successfully" || failed=1
   popd
   return $failed
 }


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

* enabling the `run_e2e_new_tests` function
* updating "rekt test" image versions (a bit of manual work, currently)

