### PR TITLE
[release-v1.2] Going with debug to reduce verbosity for retention duration default usage

### DIFF
--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -548,7 +548,7 @@ func (r *Reconciler) topicConfig(logger *zap.Logger, cm *corev1.ConfigMap, chann
 	retentionDuration, err := channel.Spec.ParseRetentionDuration()
 	if err != nil {
 		// Should never happen with webhook defaulting and validation in place.
-		logger.Error("Error parsing RetentionDuration, using default instead", zap.String("RetentionDuration", channel.Spec.RetentionDuration), zap.Error(err))
+		logger.Debug("Error parsing RetentionDuration, using default instead", zap.String("RetentionDuration", channel.Spec.RetentionDuration), zap.Error(err))
 		retentionDuration = constants.DefaultRetentionDuration
 	}
 	retentionMillisString := strconv.FormatInt(retentionDuration.Milliseconds(), 10)


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

No reason to do an error log, since we do have a default value to be used. Going with debug to reduce verbosity...