### PR TITLE
Update patches for rekt images 1.2

### DIFF
--- a/openshift/patches/override-rekt-images.patch
+++ b/openshift/patches/override-rekt-images.patch
@@ -7,7 +7,7 @@ index 7cd5e8e5..ddaafaaf 100644
    containers:
      - name: library
 -      image: ko://knative.dev/eventing/test/test_images/event-library
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-event-library
++      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-event-library
        imagePullPolicy: "IfNotPresent"
  
  ---
@@ -20,7 +20,7 @@ index 207c3d68..63858bce 100644
    containers:
      - name: flaker
 -      image: ko://knative.dev/eventing/test/test_images/event-flaker
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-event-flaker
++      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-event-flaker
        imagePullPolicy: "IfNotPresent"
        env:
          - name: "K_SINK"
@@ -46,7 +46,7 @@ index f480b459..4454798b 100644
        containers:
        - name: heartbeats
 -        image: ko://knative.dev/eventing/test/test_images/heartbeats
-+        image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-heartbeats
++        image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-heartbeats
          args:
          - --period=1
          env:
@@ -59,7 +59,7 @@ index eb823ca8..fe032ba8 100644
    containers:
      - name: event-sender
 -      image: ko://knative.dev/eventing/test/test_images/event-sender
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-event-sender
++      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-event-sender
  
 diff --git a/vendor/knative.dev/eventing/test/test_images/heartbeats/pod.yaml b/vendor/knative.dev/eventing/test/test_images/heartbeats/pod.yaml
 index 5b212ebe..ba435ce0 100644
@@ -70,7 +70,7 @@ index 5b212ebe..ba435ce0 100644
    containers:
      - name: heartbeats
 -      image: ko://knative.dev/eventing/test/test_images/heartbeats
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-heartbeats
++      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-heartbeats
  
 diff --git a/vendor/knative.dev/eventing/test/test_images/performance/pod.yaml b/vendor/knative.dev/eventing/test/test_images/performance/pod.yaml
 index dbe1a975..57e23e9f 100644
@@ -81,7 +81,7 @@ index dbe1a975..57e23e9f 100644
    containers:
      - name: performance
 -      image: ko://knative.dev/eventing/test/test_images/performance
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-performance
++      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-performance
  
 diff --git a/vendor/knative.dev/eventing/test/test_images/print/pod.yaml b/vendor/knative.dev/eventing/test/test_images/print/pod.yaml
 index 478e16c0..61f55c89 100644
@@ -92,7 +92,7 @@ index 478e16c0..61f55c89 100644
    containers:
      - name: helloworld
 -      image: ko://knative.dev/eventing/test/test_images/print
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-print
++      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-print
  
 diff --git a/vendor/knative.dev/eventing/test/test_images/recordevents/pod.yaml b/vendor/knative.dev/eventing/test/test_images/recordevents/pod.yaml
 index 0cd61e5d..409311db 100644
@@ -103,7 +103,7 @@ index 0cd61e5d..409311db 100644
    containers:
      - name: recordevents
 -      image: ko://knative.dev/eventing/test/test_images/recordevents
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-recordevents
++      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-recordevents
  
 diff --git a/vendor/knative.dev/eventing/test/test_images/request-sender/pod.yaml b/vendor/knative.dev/eventing/test/test_images/request-sender/pod.yaml
 index 20a694ca..0c5b005d 100644
@@ -114,7 +114,7 @@ index 20a694ca..0c5b005d 100644
    containers:
      - name: request-sender
 -      image: ko://knative.dev/eventing/test/test_images/request-sender
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-request-sender
++      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-request-sender
  
 diff --git a/vendor/knative.dev/eventing/test/test_images/wathola-fetcher/pod.yaml b/vendor/knative.dev/eventing/test/test_images/wathola-fetcher/pod.yaml
 index d6377098..11fb917a 100644
@@ -125,7 +125,7 @@ index d6377098..11fb917a 100644
    containers:
      - name: wathola-fetcher
 -      image: ko://knative.dev/eventing/test/test_images/wathola-fetcher
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-wathola-fetcher
++      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-wathola-fetcher
 diff --git a/vendor/knative.dev/eventing/test/test_images/wathola-forwarder/pod.yaml b/vendor/knative.dev/eventing/test/test_images/wathola-forwarder/pod.yaml
 index 33e87291..576f5841 100644
 --- a/vendor/knative.dev/eventing/test/test_images/wathola-forwarder/pod.yaml
@@ -135,7 +135,7 @@ index 33e87291..576f5841 100644
    containers:
      - name: wathola-forwarder
 -      image: ko://knative.dev/eventing/test/test_images/wathola-forwarder
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-wathola-forwarder
++      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-wathola-forwarder
 diff --git a/vendor/knative.dev/eventing/test/test_images/wathola-receiver/pod.yaml b/vendor/knative.dev/eventing/test/test_images/wathola-receiver/pod.yaml
 index 860e97a4..961487dc 100644
 --- a/vendor/knative.dev/eventing/test/test_images/wathola-receiver/pod.yaml
@@ -145,7 +145,7 @@ index 860e97a4..961487dc 100644
    containers:
      - name: wathola-receiver
 -      image: ko://knative.dev/eventing/test/test_images/wathola-receiver
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-wathola-receiver
++      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-wathola-receiver
 diff --git a/vendor/knative.dev/eventing/test/test_images/wathola-sender/pod.yaml b/vendor/knative.dev/eventing/test/test_images/wathola-sender/pod.yaml
 index cd9faf12..b7b3e033 100644
 --- a/vendor/knative.dev/eventing/test/test_images/wathola-sender/pod.yaml
@@ -155,4 +155,4 @@ index cd9faf12..b7b3e033 100644
    containers:
      - name: wathola-sender
 -      image: ko://knative.dev/eventing/test/test_images/wathola-sender
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-wathola-sender
++      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-wathola-sender

--- a/openshift/patches/override-rekt-images.patch
+++ b/openshift/patches/override-rekt-images.patch
@@ -7,7 +7,7 @@ index 7cd5e8e5..ddaafaaf 100644
    containers:
      - name: library
 -      image: ko://knative.dev/eventing/test/test_images/event-library
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-test-event-library
++      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-event-library
        imagePullPolicy: "IfNotPresent"
  
  ---
@@ -20,7 +20,7 @@ index 207c3d68..63858bce 100644
    containers:
      - name: flaker
 -      image: ko://knative.dev/eventing/test/test_images/event-flaker
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-test-event-flaker
++      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-event-flaker
        imagePullPolicy: "IfNotPresent"
        env:
          - name: "K_SINK"
@@ -33,7 +33,126 @@ index 80f37d08..860600a1 100644
    containers:
      - name: eventshub
 -      image: {{ .image }}
-+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-test-eventshub
++      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-eventshub
        imagePullPolicy: "IfNotPresent"
        env:
          - name: "SYSTEM_NAMESPACE"
+diff --git a/vendor/knative.dev/eventing/test/rekt/resources/containersource/containersource.yaml b/vendor/knative.dev/eventing/test/rekt/resources/containersource/containersource.yaml
+index f480b459..4454798b 100644
+--- a/vendor/knative.dev/eventing/test/rekt/resources/containersource/containersource.yaml
++++ b/vendor/knative.dev/eventing/test/rekt/resources/containersource/containersource.yaml
+@@ -42,7 +42,7 @@ spec:
+     spec:
+       containers:
+       - name: heartbeats
+-        image: ko://knative.dev/eventing/test/test_images/heartbeats
++        image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-heartbeats
+         args:
+         - --period=1
+         env:
+diff --git a/vendor/knative.dev/eventing/test/test_images/event-sender/pod.yaml b/vendor/knative.dev/eventing/test/test_images/event-sender/pod.yaml
+index eb823ca8..fe032ba8 100644
+--- a/vendor/knative.dev/eventing/test/test_images/event-sender/pod.yaml
++++ b/vendor/knative.dev/eventing/test/test_images/event-sender/pod.yaml
+@@ -5,5 +5,5 @@ metadata:
+ spec:
+   containers:
+     - name: event-sender
+-      image: ko://knative.dev/eventing/test/test_images/event-sender
++      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-event-sender
+ 
+diff --git a/vendor/knative.dev/eventing/test/test_images/heartbeats/pod.yaml b/vendor/knative.dev/eventing/test/test_images/heartbeats/pod.yaml
+index 5b212ebe..ba435ce0 100644
+--- a/vendor/knative.dev/eventing/test/test_images/heartbeats/pod.yaml
++++ b/vendor/knative.dev/eventing/test/test_images/heartbeats/pod.yaml
+@@ -5,5 +5,5 @@ metadata:
+ spec:
+   containers:
+     - name: heartbeats
+-      image: ko://knative.dev/eventing/test/test_images/heartbeats
++      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-heartbeats
+ 
+diff --git a/vendor/knative.dev/eventing/test/test_images/performance/pod.yaml b/vendor/knative.dev/eventing/test/test_images/performance/pod.yaml
+index dbe1a975..57e23e9f 100644
+--- a/vendor/knative.dev/eventing/test/test_images/performance/pod.yaml
++++ b/vendor/knative.dev/eventing/test/test_images/performance/pod.yaml
+@@ -8,5 +8,5 @@ metadata:
+ spec:
+   containers:
+     - name: performance
+-      image: ko://knative.dev/eventing/test/test_images/performance
++      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-performance
+ 
+diff --git a/vendor/knative.dev/eventing/test/test_images/print/pod.yaml b/vendor/knative.dev/eventing/test/test_images/print/pod.yaml
+index 478e16c0..61f55c89 100644
+--- a/vendor/knative.dev/eventing/test/test_images/print/pod.yaml
++++ b/vendor/knative.dev/eventing/test/test_images/print/pod.yaml
+@@ -5,5 +5,5 @@ metadata:
+ spec:
+   containers:
+     - name: helloworld
+-      image: ko://knative.dev/eventing/test/test_images/print
++      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-print
+ 
+diff --git a/vendor/knative.dev/eventing/test/test_images/recordevents/pod.yaml b/vendor/knative.dev/eventing/test/test_images/recordevents/pod.yaml
+index 0cd61e5d..409311db 100644
+--- a/vendor/knative.dev/eventing/test/test_images/recordevents/pod.yaml
++++ b/vendor/knative.dev/eventing/test/test_images/recordevents/pod.yaml
+@@ -5,5 +5,5 @@ metadata:
+ spec:
+   containers:
+     - name: recordevents
+-      image: ko://knative.dev/eventing/test/test_images/recordevents
++      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-recordevents
+ 
+diff --git a/vendor/knative.dev/eventing/test/test_images/request-sender/pod.yaml b/vendor/knative.dev/eventing/test/test_images/request-sender/pod.yaml
+index 20a694ca..0c5b005d 100644
+--- a/vendor/knative.dev/eventing/test/test_images/request-sender/pod.yaml
++++ b/vendor/knative.dev/eventing/test/test_images/request-sender/pod.yaml
+@@ -5,5 +5,5 @@ metadata:
+ spec:
+   containers:
+     - name: request-sender
+-      image: ko://knative.dev/eventing/test/test_images/request-sender
++      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-request-sender
+ 
+diff --git a/vendor/knative.dev/eventing/test/test_images/wathola-fetcher/pod.yaml b/vendor/knative.dev/eventing/test/test_images/wathola-fetcher/pod.yaml
+index d6377098..11fb917a 100644
+--- a/vendor/knative.dev/eventing/test/test_images/wathola-fetcher/pod.yaml
++++ b/vendor/knative.dev/eventing/test/test_images/wathola-fetcher/pod.yaml
+@@ -5,4 +5,4 @@ metadata:
+ spec:
+   containers:
+     - name: wathola-fetcher
+-      image: ko://knative.dev/eventing/test/test_images/wathola-fetcher
++      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-wathola-fetcher
+diff --git a/vendor/knative.dev/eventing/test/test_images/wathola-forwarder/pod.yaml b/vendor/knative.dev/eventing/test/test_images/wathola-forwarder/pod.yaml
+index 33e87291..576f5841 100644
+--- a/vendor/knative.dev/eventing/test/test_images/wathola-forwarder/pod.yaml
++++ b/vendor/knative.dev/eventing/test/test_images/wathola-forwarder/pod.yaml
+@@ -5,4 +5,4 @@ metadata:
+ spec:
+   containers:
+     - name: wathola-forwarder
+-      image: ko://knative.dev/eventing/test/test_images/wathola-forwarder
++      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-wathola-forwarder
+diff --git a/vendor/knative.dev/eventing/test/test_images/wathola-receiver/pod.yaml b/vendor/knative.dev/eventing/test/test_images/wathola-receiver/pod.yaml
+index 860e97a4..961487dc 100644
+--- a/vendor/knative.dev/eventing/test/test_images/wathola-receiver/pod.yaml
++++ b/vendor/knative.dev/eventing/test/test_images/wathola-receiver/pod.yaml
+@@ -5,4 +5,4 @@ metadata:
+ spec:
+   containers:
+     - name: wathola-receiver
+-      image: ko://knative.dev/eventing/test/test_images/wathola-receiver
++      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-wathola-receiver
+diff --git a/vendor/knative.dev/eventing/test/test_images/wathola-sender/pod.yaml b/vendor/knative.dev/eventing/test/test_images/wathola-sender/pod.yaml
+index cd9faf12..b7b3e033 100644
+--- a/vendor/knative.dev/eventing/test/test_images/wathola-sender/pod.yaml
++++ b/vendor/knative.dev/eventing/test/test_images/wathola-sender/pod.yaml
+@@ -5,4 +5,4 @@ metadata:
+ spec:
+   containers:
+     - name: wathola-sender
+-      image: ko://knative.dev/eventing/test/test_images/wathola-sender
++      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-wathola-sender

--- a/openshift/release/artifacts/eventing-kafka-broker.yaml
+++ b/openshift/release/artifacts/eventing-kafka-broker.yaml
@@ -326,7 +326,6 @@ spec:
             - "java"
           args:
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
-            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)
@@ -494,7 +493,6 @@ spec:
             - "java"
           args:
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
-            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/openshift/release/artifacts/eventing-kafka-channel.yaml
+++ b/openshift/release/artifacts/eventing-kafka-channel.yaml
@@ -325,7 +325,6 @@ spec:
             - "java"
           args:
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
-            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)
@@ -493,7 +492,6 @@ spec:
             - "java"
           args:
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
-            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/openshift/release/artifacts/eventing-kafka-sink.yaml
+++ b/openshift/release/artifacts/eventing-kafka-sink.yaml
@@ -262,7 +262,6 @@ spec:
             - "java"
           args:
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
-            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/openshift/release/artifacts/eventing-kafka-source.yaml
+++ b/openshift/release/artifacts/eventing-kafka-source.yaml
@@ -326,7 +326,6 @@ spec:
             - "java"
           args:
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
-            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/vendor/knative.dev/eventing-kafka/test/e2e/helpers/channel_subscription_ready_test_helper.go
+++ b/vendor/knative.dev/eventing-kafka/test/e2e/helpers/channel_subscription_ready_test_helper.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	. "github.com/cloudevents/sdk-go/v2/test"
+	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	channelsv1beta1 "knative.dev/eventing-kafka/pkg/apis/messaging/v1beta1"
+	contribtestlib "knative.dev/eventing-kafka/test/lib"
+	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/eventing/test/lib/recordevents"
+	"knative.dev/eventing/test/lib/resources"
+)
+
+const (
+	kafkaChannelName    = "kafka-sub-ready-channel"
+	kafkaSub0           = "kafka-sub-0"
+	kafkaSub1           = "kafka-sub-1"
+	recordEventsPodName = "e2e-channel-sub-ready-recordevents-pod"
+	eventSenderName     = "e2e-channel-event-sender-pod"
+)
+
+func scaleDispatcherDeployment(ctx context.Context, t *testing.T, desiredReplicas int32, client *testlib.Client) {
+	dispatcherDeployment, err := client.Kube.AppsV1().Deployments("knative-eventing").Get(ctx, "kafka-ch-dispatcher", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unable to get kafka-ch-dispatcher deployment: %v", err)
+	}
+	if *dispatcherDeployment.Spec.Replicas != desiredReplicas {
+		desired := dispatcherDeployment.DeepCopy()
+		*desired.Spec.Replicas = desiredReplicas
+		_, err := client.Kube.AppsV1().Deployments("knative-eventing").Update(ctx, desired, metav1.UpdateOptions{})
+		if err != nil {
+			t.Fatalf("Unable to update kafka-ch-dispatcher deployment to %d replica: %v", desiredReplicas, err)
+		}
+		// we actively do NOT wait for deployments to be ready so we can check state below
+	}
+}
+
+func readyDispatcherPodsCheck(ctx context.Context, t *testing.T, client *testlib.Client) int32 {
+	dispatcherDeployment, err := client.Kube.AppsV1().Deployments("knative-eventing").Get(ctx, "kafka-ch-dispatcher", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unable to get kafka-ch-dispatcher deployment: %v", err)
+	}
+	return dispatcherDeployment.Status.ReadyReplicas
+}
+
+func createKafkaChannel(client *testlib.Client, kafkaChannelMeta metav1.TypeMeta, kafkaChannelName string) {
+	kafkaChannelV1Beta1 := &channelsv1beta1.KafkaChannel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: kafkaChannelName,
+		},
+		Spec: channelsv1beta1.KafkaChannelSpec{
+			NumPartitions: 3,
+		},
+	}
+	contribtestlib.CreateKafkaChannelV1Beta1OrFail(client, kafkaChannelV1Beta1)
+}
+
+func ChannelSubscriptionScaleReadyHelper(
+	ctx context.Context,
+	t *testing.T,
+	channelTestRunner testlib.ComponentsTestRunner,
+	options ...testlib.SetupClientOption) {
+
+	eventSource := fmt.Sprintf("http://%s.svc/", eventSenderName)
+
+	channelTestRunner.RunTests(t, testlib.FeatureBasic, func(st *testing.T, kafkaChannelMeta metav1.TypeMeta) {
+		client := testlib.Setup(st, true, options...)
+		defer testlib.TearDown(client)
+
+		scaleDispatcherDeployment(ctx, st, 1, client)
+		createKafkaChannel(client, kafkaChannelMeta, kafkaChannelName)
+		client.WaitForResourceReadyOrFail(kafkaChannelName, &kafkaChannelMeta)
+
+		eventTracker, _ := recordevents.StartEventRecordOrFail(ctx, client, recordEventsPodName)
+		client.CreateSubscriptionOrFail(
+			kafkaSub0,
+			kafkaChannelName,
+			&kafkaChannelMeta,
+			resources.WithSubscriberForSubscription(recordEventsPodName),
+		)
+		client.WaitForAllTestResourcesReadyOrFail(ctx)
+
+		scaleDispatcherDeployment(ctx, st, 4, client)
+		client.WaitForResourceReadyOrFail(kafkaSub0, testlib.SubscriptionTypeMeta) //this should still be ready
+
+		client.CreateSubscriptionOrFail(
+			kafkaSub1,
+			kafkaChannelName,
+			&kafkaChannelMeta,
+			resources.WithSubscriberForSubscription(recordEventsPodName),
+		)
+		for readyDispatcherPodsCheck(ctx, st, client) < 3 {
+			subObj, err := client.Eventing.MessagingV1().Subscriptions(client.Namespace).Get(ctx, kafkaSub1, metav1.GetOptions{})
+			if err != nil {
+				st.Fatalf("Could not get v1 subscription object %q: %v", subObj.Name, err)
+			}
+			if subObj.Status.IsReady() {
+				st.Fatalf("Subscription: %s, marked ready before dispatcher pods ready", subObj.Name)
+			}
+		}
+		client.WaitForResourceReadyOrFail(kafkaSub1, testlib.SubscriptionTypeMeta)
+		// send CloudEvent to the first channel
+		event := cloudevents.NewEvent()
+		event.SetID("test")
+		event.SetSource(eventSource)
+		event.SetType(testlib.DefaultEventType)
+
+		body := fmt.Sprintf(`{"msg":"TestSingleEvent %s"}`, uuid.New().String())
+		if err := event.SetData(cloudevents.ApplicationJSON, []byte(body)); err != nil {
+			st.Fatalf("Cannot set the payload of the event: %s", err.Error())
+		}
+
+		client.SendEventToAddressable(ctx, eventSenderName, kafkaChannelName, &kafkaChannelMeta, event)
+		// verify the logger service receives the event
+		eventTracker.AssertAtLeast(1, recordevents.MatchEvent(
+			HasSource(eventSource),
+			HasData([]byte(body)),
+		))
+	})
+}

--- a/vendor/knative.dev/eventing/test/rekt/resources/containersource/containersource.yaml
+++ b/vendor/knative.dev/eventing/test/rekt/resources/containersource/containersource.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: heartbeats
-        image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-heartbeats
+        image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-heartbeats
         args:
         - --period=1
         env:

--- a/vendor/knative.dev/eventing/test/rekt/resources/eventlibrary/eventlibrary.yaml
+++ b/vendor/knative.dev/eventing/test/rekt/resources/eventlibrary/eventlibrary.yaml
@@ -23,7 +23,7 @@ spec:
   restartPolicy: "Never"
   containers:
     - name: library
-      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-event-library
+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-event-library
       imagePullPolicy: "IfNotPresent"
 
 ---

--- a/vendor/knative.dev/eventing/test/rekt/resources/flaker/flaker.yaml
+++ b/vendor/knative.dev/eventing/test/rekt/resources/flaker/flaker.yaml
@@ -23,7 +23,7 @@ spec:
   restartPolicy: "Never"
   containers:
     - name: flaker
-      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-event-flaker
+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-event-flaker
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "K_SINK"

--- a/vendor/knative.dev/eventing/test/test_images/event-sender/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/event-sender/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: event-sender
-      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-event-sender
+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-event-sender
 

--- a/vendor/knative.dev/eventing/test/test_images/heartbeats/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/heartbeats/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: heartbeats
-      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-heartbeats
+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-heartbeats
 

--- a/vendor/knative.dev/eventing/test/test_images/performance/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/performance/pod.yaml
@@ -8,5 +8,5 @@ metadata:
 spec:
   containers:
     - name: performance
-      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-performance
+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-performance
 

--- a/vendor/knative.dev/eventing/test/test_images/print/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/print/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: helloworld
-      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-print
+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-print
 

--- a/vendor/knative.dev/eventing/test/test_images/recordevents/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/recordevents/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: recordevents
-      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-recordevents
+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-recordevents
 

--- a/vendor/knative.dev/eventing/test/test_images/request-sender/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/request-sender/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: request-sender
-      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-request-sender
+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-request-sender
 

--- a/vendor/knative.dev/eventing/test/test_images/wathola-fetcher/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/wathola-fetcher/pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
     - name: wathola-fetcher
-      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-wathola-fetcher
+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-wathola-fetcher

--- a/vendor/knative.dev/eventing/test/test_images/wathola-forwarder/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/wathola-forwarder/pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
     - name: wathola-forwarder
-      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-wathola-forwarder
+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-wathola-forwarder

--- a/vendor/knative.dev/eventing/test/test_images/wathola-receiver/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/wathola-receiver/pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
     - name: wathola-receiver
-      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-wathola-receiver
+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-wathola-receiver

--- a/vendor/knative.dev/eventing/test/test_images/wathola-sender/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/wathola-sender/pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
     - name: wathola-sender
-      image: registry.ci.openshift.org/openshift/knative-v1.2.1:knative-eventing-test-wathola-sender
+      image: registry.ci.openshift.org/openshift/knative-v1.2.3:knative-eventing-kafka-broker-test-wathola-sender


### PR DESCRIPTION
* Adding a correct version rekt test image replacement patch
* MAKE RELEASE  (does revert FIPS, on purpose).


Next: do a better FIPS patch 