### PR TITLE
[v1.2] KafkaChannel migrator adds the secret ref only when previously specificied

### DIFF
--- a/control-plane/cmd/post-install/kafka_channel_migrator.go
+++ b/control-plane/cmd/post-install/kafka_channel_migrator.go
@@ -30,7 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	kcs "knative.dev/eventing-kafka/pkg/client/clientset/versioned"
@@ -218,8 +218,12 @@ func (m *kafkaChannelMigrator) migrateConfigmap(ctx context.Context, logger *zap
 
 	patches := []string{
 		fmt.Sprintf(`{"op":"replace", "path": "/data/bootstrap.servers", "value": "%s"}`, oldconfig.Kafka.Brokers),
-		fmt.Sprintf(`{"op":"replace", "path": "/data/auth.secret.ref.namespace", "value": "%s"}`, oldconfig.Kafka.AuthSecretNamespace),
-		fmt.Sprintf(`{"op":"replace", "path": "/data/auth.secret.ref.name", "value": "%s"}`, oldconfig.Kafka.AuthSecretName),
+	}
+	if oldconfig.Kafka.AuthSecretNamespace != "" {
+		patches = append(patches, fmt.Sprintf(`{"op":"replace", "path": "/data/auth.secret.ref.namespace", "value": "%s"}`, oldconfig.Kafka.AuthSecretNamespace))
+	}
+	if oldconfig.Kafka.AuthSecretName != "" {
+		patches = append(patches, fmt.Sprintf(`{"op":"replace", "path": "/data/auth.secret.ref.name", "value": "%s"}`, oldconfig.Kafka.AuthSecretName))
 	}
 
 	logger.Infof("Patching configmap %s with patch %s", newConfigmapName, patches)


### PR DESCRIPTION
 I get this error after upgrading
 ```
"ReconcileKind","error":"failed to get secret: failed to get secret knative-eventing/: resource name may not be empty"
```

The CM created by the post-install job is like this:
```
        {
            "apiVersion": "v1",
            "data": {
                "auth.secret.ref.name": "",
                "auth.secret.ref.namespace": "",
                "bootstrap.servers": "my-cluster-kafka-bootstrap.kafka:9092"
            },
            "kind": "ConfigMap",
            "metadata": {
                "creationTimestamp": "2022-05-10T18:33:49Z",
                "labels": {
                    "kafka.eventing.knative.dev/release": "v1.2.3"
                },
                "name": "kafka-channel-config",
                "namespace": "knative-eventing",
                "ownerReferences": [
                    {
                        "apiVersion": "operator.serverless.openshift.io/v1alpha1",
                        "blockOwnerDeletion": true,
                        "controller": true,
                        "kind": "KnativeKafka",
                        "name": "knative-kafka",
                        "uid": "ffa91342-e17c-422b-969a-f7aaa5681302"
                    }
                ],
                "resourceVersion": "94353",
                "uid": "e1d0efad-395e-4554-9eb8-860698361951"
            }
        }
```
and as you can see we're adding empty strings to the CM and that causes the reconciler to try to
read a non-existing secret.

See my root causing chat https://coreos.slack.com/archives/CEXRYS5QC/p1652252184072199

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>