### PR TITLE
[release-v1.2 ]Disable unnecessary metrics (#2156)

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
@@ -116,6 +116,11 @@ public class Metrics {
     final var registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
     return new MicrometerMetricsOptions()
       .setEnabled(true)
+      .addDisabledMetricsCategory(MetricsDomain.HTTP_CLIENT)
+      .addDisabledMetricsCategory(MetricsDomain.HTTP_SERVER)
+      .addDisabledMetricsCategory(MetricsDomain.VERTICLES)
+      .addDisabledMetricsCategory(MetricsDomain.NET_CLIENT)
+      .addDisabledMetricsCategory(MetricsDomain.NET_SERVER)
       .addDisabledMetricsCategory(MetricsDomain.EVENT_BUS)
       .addDisabledMetricsCategory(MetricsDomain.DATAGRAM_SOCKET)
       // NAMED_POOL allocates a lot, so disable it.


### PR DESCRIPTION
> Backport from upstream

Vert.x's client, server and verticles metrics adds a lot of
allocations and their metrics exposed add little value in a
kubernetes environment or our case.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

Co-authored-by: Pierangelo Di Pilato <pierdipi@redhat.com>