### PR TITLE
[release-v1.2] Remove old Config Kafka CM for old/legacy channel

### DIFF
--- a/control-plane/cmd/post-install/kafka_channel_post_migration_deleter.go
+++ b/control-plane/cmd/post-install/kafka_channel_post_migration_deleter.go
@@ -137,6 +137,15 @@ func (d *kafkaChannelPostMigrationDeleter) Delete(ctx context.Context) error {
 		return fmt.Errorf("failed to delete Lease %s: %w", kafkaChannelDispatcherLease, err)
 	}
 
+	// Delete configmap/config-kafka
+	const kafkaChannelConfigmap = "config-kafka"
+	err = d.k8s.
+		CoreV1().
+		ConfigMaps(system.Namespace()).
+		Delete(ctx, kafkaChannelConfigmap, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete Configmap %s: %w", kafkaChannelConfigmap, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Porting upstream 2204 to here

