### PR TITLE
[release-v1.2] Bind and close Kafka client metrics provider asynchronously (#2175)

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/AsyncCloseable.java
@@ -79,38 +79,4 @@ public interface AsyncCloseable extends Closeable {
         v -> compose(closeableIterator)
       );
   }
-
-  /**
-   * Wrap the provided blocking {@link AutoCloseable} into an {@link AsyncCloseable}.
-   * This is going to use the current context when the close is invoked.
-   *
-   * @param closeable the closeable to wrap
-   * @return the wrapped closeable
-   */
-  static AsyncCloseable wrapAutoCloseable(AutoCloseable closeable) {
-    return () -> {
-      Context context = Vertx.currentContext();
-
-      if (context == null) {
-        // I'm not on the event loop, I can just execute this as is!
-        try {
-          closeable.close();
-          return Future.succeededFuture();
-        } catch (Exception e) {
-          return Future.failedFuture(e);
-        }
-      }
-
-      // I'm on the event loop, I need to execute blocking.
-      return context.executeBlocking(promise -> {
-        try {
-          closeable.close();
-          promise.complete();
-        } catch (Exception e) {
-          promise.fail(e);
-        }
-      });
-    };
-  }
-
 }

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/IngressProducerReconcilableStore.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/impl/IngressProducerReconcilableStore.java
@@ -235,7 +235,7 @@ public class IngressProducerReconcilableStore implements IngressReconcilerListen
     private static final Logger logger = LoggerFactory.getLogger(ProducerHolder.class);
 
     private final KafkaProducer<String, CloudEvent> producer;
-    private final AutoCloseable producerMeterBinder;
+    private final AsyncCloseable producerMeterBinder;
 
     ProducerHolder(final KafkaProducer<String, CloudEvent> producer) {
       this.producer = producer;
@@ -259,10 +259,9 @@ public class IngressProducerReconcilableStore implements IngressReconcilerListen
     }
 
     private Future<Void> closeNow() {
-      return AsyncCloseable.compose(
-        producer::close,
-        AsyncCloseable.wrapAutoCloseable(this.producerMeterBinder)
-      ).close();
+      return AsyncCloseable
+        .compose(this.producerMeterBinder, producer::close)
+        .close();
     }
   }
 


### PR DESCRIPTION
The binding and close process of the metrics reporter is blocking,
so that blocks our data plane verticle deployer.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>