### PR TITLE
[release-v1.2] Use openshift knative kafkacat

### DIFF
--- a/openshift/patches/use_kafkacat_from_ocp.patch
+++ b/openshift/patches/use_kafkacat_from_ocp.patch
@@ -1,0 +1,13 @@
+diff --git a/vendor/knative.dev/eventing-kafka/test/e2e/helpers/kafka_helper.go b/vendor/knative.dev/eventing-kafka/test/e2e/helpers/kafka_helper.go
+index f48c5708..9c750aba 100644
+--- a/vendor/knative.dev/eventing-kafka/test/e2e/helpers/kafka_helper.go
++++ b/vendor/knative.dev/eventing-kafka/test/e2e/helpers/kafka_helper.go
+@@ -51,7 +51,7 @@ const (
+ 	strimziTopicResource = "kafkatopics"
+ 	interval             = 3 * time.Second
+ 	timeout              = 4 * time.Minute
+-	kafkaCatImage        = "docker.io/edenhill/kafkacat:1.6.0"
++	kafkaCatImage        = "quay.io/openshift-knative/kafkacat:1.6.0"
+ )
+ 
+ var (

--- a/vendor/knative.dev/eventing-kafka/test/e2e/helpers/kafka_helper.go
+++ b/vendor/knative.dev/eventing-kafka/test/e2e/helpers/kafka_helper.go
@@ -51,7 +51,7 @@ const (
 	strimziTopicResource = "kafkatopics"
 	interval             = 3 * time.Second
 	timeout              = 4 * time.Minute
-	kafkaCatImage        = "docker.io/edenhill/kafkacat:1.6.0"
+	kafkaCatImage        = "quay.io/openshift-knative/kafkacat:1.6.0"
 )
 
 var (


### PR DESCRIPTION
patch to use our stashed version of `kafkacat`