### PR TITLE
[release-v1.2] Use a constant backoff delay for probing resource ingresses (#2303)

### DIFF
--- a/control-plane/pkg/prober/async_prober.go
+++ b/control-plane/pkg/prober/async_prober.go
@@ -112,9 +112,13 @@ func (a *asyncProber) Probe(ctx context.Context, addressable Addressable, expect
 		enqueueOnce.Do(func() {
 			// Wait in a separate goroutine.
 			go func() {
+				// wait before requeue-ing, constant backoff strategy, so that we don't create a spinning
+				// loop.
+				time.Sleep(time.Second)
 				// Wait for all the prober request results and then requeue the
 				// resource.
 				wg.Wait()
+
 				a.enqueue(resourceKey)
 			}()
 		})

--- a/control-plane/pkg/prober/async_prober_test.go
+++ b/control-plane/pkg/prober/async_prober_test.go
@@ -152,9 +152,9 @@ func TestAsyncProber(t *testing.T) {
 				return status == tc.wantStatus
 			}
 
-			require.Eventuallyf(t, probeFunc, time.Second, 10*time.Millisecond, "")
-			require.GreaterOrEqual(t, int64(0), wantRequestCountMin.Load(), "")
-			require.GreaterOrEqual(t, int64(0), wantRequeueCountMin.Load(), "")
+			require.Eventuallyf(t, probeFunc, 5*time.Second, 100*time.Millisecond, "")
+			require.Eventuallyf(t, func() bool { return wantRequestCountMin.Load() == 0 }, 5*time.Second, 100*time.Millisecond, "got %d, want 0", wantRequestCountMin.Load())
+			require.Eventuallyf(t, func() bool { return wantRequeueCountMin.Load() == 0 }, 5*time.Second, 100*time.Millisecond, "got %d, want 0", wantRequeueCountMin.Load())
 		})
 	}
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/knative-sandbox/eventing-kafka-broker/commit/87b047a6bd0995c030dfb8b06f7387a29090a7f3

When resource readiness is delayed due to the latency of the
ConfigMap propagation, the controllers might enter into a spinning
loop trying to probe receivers for readiness.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>