### PR TITLE
install_serverless directly install already kafka 

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -70,11 +70,6 @@ function timeout() {
   return 0
 }
 
-function kafka_setup() {
-  echo ">> Prepare to deploy Strimzi"
-  ./test/kafka/kafka_setup.sh || fail_test "Failed to set up Kafka cluster"
-}
-
 function install_serverless() {
   header "Installing Serverless Operator"
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

`install_serverless` directly installs kafka script, so no need to keep this func

