### PR TITLE
[release-v1.3] Only update finalizers on secrets 1.3 ocp

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/200-controller-cluster-role.yaml
@@ -68,8 +68,14 @@ rules:
     verbs:
       - list
       - get
-      - update
       - watch
+
+  - apiGroups:
+      - "*"
+    resources:
+      - secrets/finalizers
+    verbs:
+      - update
 
   # Scheduler permissions
   - apiGroups:

--- a/openshift/release/artifacts/eventing-kafka-controller.yaml
+++ b/openshift/release/artifacts/eventing-kafka-controller.yaml
@@ -985,8 +985,14 @@ rules:
     verbs:
       - list
       - get
-      - update
       - watch
+
+  - apiGroups:
+      - "*"
+    resources:
+      - secrets/finalizers
+    verbs:
+      - update
 
   # Scheduler permissions
   - apiGroups:


### PR DESCRIPTION
The 1.3 version of https://github.com/openshift-knative/eventing-kafka-broker/pull/330 