### PR TITLE
Self contained dockerfiles for images

### DIFF
--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD ${bin} /usr/bin/${bin}
+COPY --from=builder /go/bin/${bin} /usr/bin/${bin}
 ENTRYPOINT ["/usr/bin/${bin}"]

--- a/openshift/ci-operator/knative-images/kafka-controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/kafka-controller/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD kafka-controller /usr/bin/kafka-controller
+COPY --from=builder /go/bin/kafka-controller /usr/bin/kafka-controller
 ENTRYPOINT ["/usr/bin/kafka-controller"]

--- a/openshift/ci-operator/knative-images/post-install/Dockerfile
+++ b/openshift/ci-operator/knative-images/post-install/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD post-install /usr/bin/post-install
+COPY --from=builder /go/bin/post-install /usr/bin/post-install
 ENTRYPOINT ["/usr/bin/post-install"]

--- a/openshift/ci-operator/knative-images/webhook-kafka/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook-kafka/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD webhook-kafka /usr/bin/webhook-kafka
+COPY --from=builder /go/bin/webhook-kafka /usr/bin/webhook-kafka
 ENTRYPOINT ["/usr/bin/webhook-kafka"]

--- a/openshift/ci-operator/knative-test-images/committed-offset/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/committed-offset/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD committed-offset /usr/bin/committed-offset
+COPY --from=builder /go/bin/committed-offset /usr/bin/committed-offset
 ENTRYPOINT ["/usr/bin/committed-offset"]

--- a/openshift/ci-operator/knative-test-images/consumer-group-lag-provider-test/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/consumer-group-lag-provider-test/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD consumer-group-lag-provider-test /usr/bin/consumer-group-lag-provider-test
+COPY --from=builder /go/bin/consumer-group-lag-provider-test /usr/bin/consumer-group-lag-provider-test
 ENTRYPOINT ["/usr/bin/consumer-group-lag-provider-test"]

--- a/openshift/ci-operator/knative-test-images/event-flaker/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/event-flaker/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD event-flaker /usr/bin/event-flaker
+COPY --from=builder /go/bin/event-flaker /usr/bin/event-flaker
 ENTRYPOINT ["/usr/bin/event-flaker"]

--- a/openshift/ci-operator/knative-test-images/event-library/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/event-library/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD event-library /usr/bin/event-library
+COPY --from=builder /go/bin/event-library /usr/bin/event-library
 ENTRYPOINT ["/usr/bin/event-library"]

--- a/openshift/ci-operator/knative-test-images/event-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/event-sender/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD event-sender /usr/bin/event-sender
+COPY --from=builder /go/bin/event-sender /usr/bin/event-sender
 ENTRYPOINT ["/usr/bin/event-sender"]

--- a/openshift/ci-operator/knative-test-images/eventshub/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/eventshub/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD eventshub /usr/bin/eventshub
+COPY --from=builder /go/bin/eventshub /usr/bin/eventshub
 ENTRYPOINT ["/usr/bin/eventshub"]

--- a/openshift/ci-operator/knative-test-images/heartbeats/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/heartbeats/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD heartbeats /usr/bin/heartbeats
+COPY --from=builder /go/bin/heartbeats /usr/bin/heartbeats
 ENTRYPOINT ["/usr/bin/heartbeats"]

--- a/openshift/ci-operator/knative-test-images/kafka-consumer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/kafka-consumer/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD kafka-consumer /usr/bin/kafka-consumer
+COPY --from=builder /go/bin/kafka-consumer /usr/bin/kafka-consumer
 ENTRYPOINT ["/usr/bin/kafka-consumer"]

--- a/openshift/ci-operator/knative-test-images/partitions-replication-verifier/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/partitions-replication-verifier/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD partitions-replication-verifier /usr/bin/partitions-replication-verifier
+COPY --from=builder /go/bin/partitions-replication-verifier /usr/bin/partitions-replication-verifier
 ENTRYPOINT ["/usr/bin/partitions-replication-verifier"]

--- a/openshift/ci-operator/knative-test-images/performance/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/performance/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD performance /usr/bin/performance
+COPY --from=builder /go/bin/performance /usr/bin/performance
 ENTRYPOINT ["/usr/bin/performance"]

--- a/openshift/ci-operator/knative-test-images/print/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/print/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD print /usr/bin/print
+COPY --from=builder /go/bin/print /usr/bin/print
 ENTRYPOINT ["/usr/bin/print"]

--- a/openshift/ci-operator/knative-test-images/recordevents/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/recordevents/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD recordevents /usr/bin/recordevents
+COPY --from=builder /go/bin/recordevents /usr/bin/recordevents
 ENTRYPOINT ["/usr/bin/recordevents"]

--- a/openshift/ci-operator/knative-test-images/request-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/request-sender/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD request-sender /usr/bin/request-sender
+COPY --from=builder /go/bin/request-sender /usr/bin/request-sender
 ENTRYPOINT ["/usr/bin/request-sender"]

--- a/openshift/ci-operator/knative-test-images/wathola-fetcher/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-fetcher/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD wathola-fetcher /usr/bin/wathola-fetcher
+COPY --from=builder /go/bin/wathola-fetcher /usr/bin/wathola-fetcher
 ENTRYPOINT ["/usr/bin/wathola-fetcher"]

--- a/openshift/ci-operator/knative-test-images/wathola-forwarder/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-forwarder/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD wathola-forwarder /usr/bin/wathola-forwarder
+COPY --from=builder /go/bin/wathola-forwarder /usr/bin/wathola-forwarder
 ENTRYPOINT ["/usr/bin/wathola-forwarder"]

--- a/openshift/ci-operator/knative-test-images/wathola-receiver/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-receiver/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD wathola-receiver /usr/bin/wathola-receiver
+COPY --from=builder /go/bin/wathola-receiver /usr/bin/wathola-receiver
 ENTRYPOINT ["/usr/bin/wathola-receiver"]

--- a/openshift/ci-operator/knative-test-images/wathola-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-sender/Dockerfile
@@ -1,5 +1,10 @@
 # Do not edit! This file was generate via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 
-ADD wathola-sender /usr/bin/wathola-sender
+COPY --from=builder /go/bin/wathola-sender /usr/bin/wathola-sender
 ENTRYPOINT ["/usr/bin/wathola-sender"]


### PR DESCRIPTION
In this patch, I'm removing the requirement to build binaries
on the host and then build the image by copying the binary.

This improves consistency because the build isn't different
based on the environment is built.
In addition, this simplifies my openshift/release reconciler.

See only the changes in `openshift/ci-operator/Dockerfile.in`
the rest is generated by `make generate-dockerfiles`

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>