### PR TITLE
Use target to generate release

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -21,6 +21,6 @@ git commit -sm ":fire: remove unneeded workflows" .github/
 
 # Generate our OCP artifacts
 make generate-dockerfiles
-make RELEASE=$release generate-release
+make RELEASE="${target}" generate-release
 git add openshift OWNERS Makefile
 git commit -m "Add openshift specific files."


### PR DESCRIPTION
`release` is the upstream release

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>