### PR TITLE
Patches are already applied when running make generate-release

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -26,14 +26,6 @@ make generate-dockerfiles
 make RELEASE=ci generate-release
 git add openshift OWNERS Makefile
 git commit -m ":open_file_folder: Update openshift specific files."
-
-# Apply patches if present
-PATCHES_DIR="$(pwd)/openshift/patches/"
-if [ -d "$PATCHES_DIR" ] && [ "$(ls -A "$PATCHES_DIR")" ]; then
-    git apply openshift/patches/*
-    make RELEASE=ci generate-release
-    git commit -am ":fire: Apply carried patches."
-fi
 git push -f openshift ${REPO_BRANCH}
 
 # Trigger CI


### PR DESCRIPTION
See https://github.com/openshift-knative/eventing-kafka-broker/blob/bfbcd5a2d87e6614ea2903142daa7c34572c271f/openshift/release/generate-release.sh#L7-L8

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>