### PR TITLE
[main] Include vendor and other changes in update-to-head.sh

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -24,7 +24,7 @@ git commit -sm ":fire: remove unneeded workflows" .github/
 # Generate our OCP artifacts
 make generate-dockerfiles
 make RELEASE=ci generate-release
-git add openshift OWNERS Makefile
+git add .
 git commit -m ":open_file_folder: Update openshift specific files."
 git push -f openshift ${REPO_BRANCH}
 


### PR DESCRIPTION
As it was, it is missing some vendor changes created by
`make generate-release`

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>