### PR TITLE
[SRVKE-1249][release-v1.3] Close OffsetManager on init offsets

### DIFF
--- a/openshift/patches/close_offsetmanager.patch
+++ b/openshift/patches/close_offsetmanager.patch
@@ -1,0 +1,12 @@
+diff --git a/vendor/knative.dev/eventing-kafka/pkg/common/kafka/offset/offsets.go b/vendor/knative.dev/eventing-kafka/pkg/common/kafka/offset/offsets.go
+index 5caab169..43a33f5d 100644
+--- a/vendor/knative.dev/eventing-kafka/pkg/common/kafka/offset/offsets.go
++++ b/vendor/knative.dev/eventing-kafka/pkg/common/kafka/offset/offsets.go
+@@ -37,6 +37,7 @@ func InitOffsets(ctx context.Context, kafkaClient sarama.Client, kafkaAdminClien
+ 	if err != nil {
+ 		return -1, err
+ 	}
++	defer offsetManager.Close()
+ 
+ 	totalPartitions, topicPartitions, err := retrieveAllPartitions(topics, kafkaClient)
+ 	if err != nil {

--- a/vendor/knative.dev/eventing-kafka/pkg/common/kafka/offset/offsets.go
+++ b/vendor/knative.dev/eventing-kafka/pkg/common/kafka/offset/offsets.go
@@ -37,6 +37,7 @@ func InitOffsets(ctx context.Context, kafkaClient sarama.Client, kafkaAdminClien
 	if err != nil {
 		return -1, err
 	}
+	defer offsetManager.Close()
 
 	totalPartitions, topicPartitions, err := retrieveAllPartitions(topics, kafkaClient)
 	if err != nil {


### PR DESCRIPTION
The OffsetManager wasn't closed after initializing the offsets
leading to go routing leaks.

Backport https://github.com/knative-sandbox/eventing-kafka/pull/1214/commits/a56979ca6e0f7981cf5a609027905c76729cdfed
using a vendor patch.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>