### PR TITLE
Skip tests that expects specific post-install job names (#220)

### DIFF
--- a/openshift/patches/SO-uses-different-post-install-job-names.patch
+++ b/openshift/patches/SO-uses-different-post-install-job-names.patch
@@ -1,0 +1,12 @@
+diff --git a/test/upgrade/postupgrade.go b/test/upgrade/postupgrade.go
+index cee2d5c1..aa57e6e4 100644
+--- a/test/upgrade/postupgrade.go
++++ b/test/upgrade/postupgrade.go
+@@ -61,6 +61,7 @@ func SinkPostUpgradeTest() pkgupgrade.Operation {
+ }
+ 
+ func verifyPostInstall(t *testing.T) {
++	t.Skip("SO uses different names")
+ 	t.Parallel()
+ 
+ 	const (

--- a/test/upgrade/postupgrade.go
+++ b/test/upgrade/postupgrade.go
@@ -67,6 +67,7 @@ func SinkPostUpgradeTest() pkgupgrade.Operation {
 }
 
 func verifyPostInstall(t *testing.T) {
+	t.Skip("SO uses different names")
 	t.Parallel()
 
 	const (


### PR DESCRIPTION
* Needed by https://github.com/openshift-knative/serverless-operator/pull/1652
* As in #219 