### PR TITLE
[main] Skip tests that expects specific post-install job names

### DIFF
--- a/openshift/patches/SO-uses-different-post-install-job-names.patch
+++ b/openshift/patches/SO-uses-different-post-install-job-names.patch
@@ -1,0 +1,12 @@
+diff --git a/test/upgrade/postupgrade.go b/test/upgrade/postupgrade.go
+index cee2d5c1..aa57e6e4 100644
+--- a/test/upgrade/postupgrade.go
++++ b/test/upgrade/postupgrade.go
+@@ -61,6 +61,7 @@ func SinkPostUpgradeTest() pkgupgrade.Operation {
+ }
+ 
+ func verifyPostInstall(t *testing.T) {
++	t.Skip("SO uses different names")
+ 	t.Parallel()
+ 
+ 	const (


### PR DESCRIPTION
Add this patch [1] to main branch.

[1] https://github.com/openshift-knative/eventing-kafka-broker/commit/249d203ec40edeef6520203f9f553afbf75f9b8a

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>