### PR TITLE
[release-v1.4] Do not generate checksum for config tracing

### DIFF
--- a/hack/update-checksums.sh
+++ b/hack/update-checksums.sh
@@ -26,7 +26,6 @@ fi
 
 source $(dirname $0)/../vendor/knative.dev/hack/library.sh
 
-go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml
 go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/control-plane/config/eventing-kafka-broker/200-controller/100-config-logging.yaml
 go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-leader-election.yaml
 go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml

--- a/openshift/patches/remove_checksum_generation_for_config_tracing.patch
+++ b/openshift/patches/remove_checksum_generation_for_config_tracing.patch
@@ -1,0 +1,12 @@
+diff --git a/hack/update-checksums.sh b/hack/update-checksums.sh
+index ad2c6310..484dbeb5 100755
+--- a/hack/update-checksums.sh
++++ b/hack/update-checksums.sh
+@@ -26,7 +26,6 @@ fi
+ 
+ source $(dirname $0)/../vendor/knative.dev/hack/library.sh
+ 
+-go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml
+ go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/control-plane/config/eventing-kafka-broker/200-controller/100-config-logging.yaml
+ go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-leader-election.yaml
+ go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml

--- a/openshift/release/artifacts/eventing-kafka-broker.yaml
+++ b/openshift/release/artifacts/eventing-kafka-broker.yaml
@@ -21,7 +21,7 @@ metadata:
   name: config-kafka-broker-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   config-kafka-broker-producer.properties: |
     key.serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -141,7 +141,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-broker-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   - apiGroups:
       - "*"
@@ -174,7 +174,7 @@ metadata:
   name: knative-kafka-broker-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 ---
 
@@ -197,7 +197,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-broker-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-broker-data-plane
@@ -230,7 +230,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-dispatcher
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -240,7 +240,7 @@ spec:
       name: kafka-broker-dispatcher
       labels:
         app: kafka-broker-dispatcher
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -264,7 +264,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kafka-broker-dispatcher
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-dispatcher
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-dispatcher
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -397,7 +397,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -407,7 +407,7 @@ spec:
       name: kafka-broker-receiver
       labels:
         app: kafka-broker-receiver
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -431,7 +431,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kafka-broker-receiver
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-receiver
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-receiver
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -549,7 +549,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     app: kafka-broker-receiver

--- a/openshift/release/artifacts/eventing-kafka-channel.yaml
+++ b/openshift/release/artifacts/eventing-kafka-channel.yaml
@@ -21,7 +21,7 @@ metadata:
   name: config-kafka-channel-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   config-kafka-channel-producer.properties: |
     key.serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -140,7 +140,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channel-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   - apiGroups:
       - "*"
@@ -173,7 +173,7 @@ metadata:
   name: knative-kafka-channel-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 ---
 
@@ -196,7 +196,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-channel-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-channel-data-plane
@@ -229,7 +229,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-dispatcher
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -239,7 +239,7 @@ spec:
       name: kafka-channel-dispatcher
       labels:
         app: kafka-channel-dispatcher
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -263,7 +263,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kafka-channel-dispatcher
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-dispatcher
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-dispatcher
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -396,7 +396,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-receiver
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -406,7 +406,7 @@ spec:
       name: kafka-channel-receiver
       labels:
         app: kafka-channel-receiver
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -430,7 +430,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kafka-channel-receiver
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-receiver
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-receiver
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -548,7 +548,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-receiver
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     app: kafka-channel-receiver

--- a/openshift/release/artifacts/eventing-kafka-controller.yaml
+++ b/openshift/release/artifacts/eventing-kafka-controller.yaml
@@ -21,7 +21,7 @@ metadata:
   name: kafka-broker-config
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   default.topic.partitions: "10"
   default.topic.replication.factor: "3"
@@ -48,7 +48,7 @@ metadata:
   labels:
     duck.knative.dev/addressable: "true"
     knative.dev/crd-install: "true"
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   group: eventing.knative.dev
   names:
@@ -318,7 +318,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: eventing-kafka-source-observer
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:
@@ -350,7 +350,7 @@ metadata:
   name: config-kafka-source-defaults
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
   annotations:
     knative.dev/example-checksum: "b6ed351d"
 data:
@@ -411,7 +411,7 @@ metadata:
   name: kafka-channel-config
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"
 ---
@@ -703,7 +703,7 @@ metadata:
   name: config-kafka-descheduler
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
     predicates: |+
                     []
@@ -752,7 +752,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
   name: config-kafka-leader-election
   namespace: knative-eventing
   annotations:
@@ -818,7 +818,7 @@ metadata:
   name: config-kafka-scheduler
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
     predicates: |+
                   [
@@ -860,7 +860,7 @@ metadata:
   name: kafka-config-logging
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   config.xml: |
     <configuration>
@@ -891,7 +891,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-kafka-addressable-resolver
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -934,7 +934,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channelable-manipulator
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
@@ -974,7 +974,7 @@ kind: ClusterRole
 metadata:
   name: kafka-controller
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   - apiGroups:
       - "*"
@@ -1177,7 +1177,7 @@ metadata:
   name: kafka-controller
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 ---
 
@@ -1200,7 +1200,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -1216,7 +1216,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller-addressable-resolver
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -1249,7 +1249,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -1259,7 +1259,7 @@ spec:
       name: kafka-controller
       labels:
         app: kafka-controller
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1285,7 +1285,7 @@ spec:
 
       containers:
         - name: controller
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-kafka-controller
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-kafka-controller
           imagePullPolicy: IfNotPresent
           env:
             - name: BROKER_DATA_PLANE_CONFIG_MAP_NAMESPACE
@@ -1424,7 +1424,7 @@ kind: ClusterRole
 metadata:
   name: kafka-webhook-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:
@@ -1536,7 +1536,7 @@ metadata:
   name: kafka-webhook-eventing
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 ---
 
@@ -1559,7 +1559,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-webhook-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: kafka-webhook-eventing
@@ -1589,7 +1589,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 webhooks:
   - admissionReviewVersions: [ "v1", "v1beta1" ]
     clientConfig:
@@ -1620,7 +1620,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: pods.defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 webhooks:
   # Dispatcher pods webhook config.
   - admissionReviewVersions: [ "v1", "v1beta1" ]
@@ -1662,7 +1662,7 @@ metadata:
   name: kafka-webhook-eventing-certs
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -1684,7 +1684,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kafka.eventing.knative.dev
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -1717,7 +1717,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -1726,7 +1726,7 @@ spec:
     metadata:
       labels:
         app: kafka-webhook-eventing
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -1747,7 +1747,7 @@ spec:
         - name: kafka-webhook-eventing
           terminationMessagePolicy: FallbackToLogsOnError
 
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-webhook-kafka
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-webhook-kafka
 
           resources:
             requests:
@@ -1812,7 +1812,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   ports:
     - name: https-webhook

--- a/openshift/release/artifacts/eventing-kafka-post-install.yaml
+++ b/openshift/release/artifacts/eventing-kafka-post-install.yaml
@@ -20,7 +20,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   - apiGroups:
       - apps
@@ -227,7 +227,7 @@ metadata:
   name: knative-kafka-controller-post-install
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -248,7 +248,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   # Storage version upgrader needs to be able to patch CRDs.
   - apiGroups:
@@ -317,7 +317,7 @@ metadata:
   name: knative-kafka-storage-version-migrator
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 
 ---
 
@@ -326,7 +326,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-storage-version-migrator
@@ -357,7 +357,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-controller-post-install
@@ -388,7 +388,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller-post-install
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -396,7 +396,7 @@ spec:
     metadata:
       labels:
         app: kafka-controller-post-install
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -404,7 +404,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: post-install
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-post-install
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-post-install
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -434,7 +434,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: "knative-kafka-storage-version-migrator"
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -442,7 +442,7 @@ spec:
     metadata:
       labels:
         app: "knative-kafka-storage-version-migrator"
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -450,7 +450,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-migrate
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-migrate
           env:
             - name: IGNORE_NOT_FOUND
               value: "true"

--- a/openshift/release/artifacts/eventing-kafka-sink.yaml
+++ b/openshift/release/artifacts/eventing-kafka-sink.yaml
@@ -21,7 +21,7 @@ metadata:
   name: config-kafka-sink-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   config-kafka-sink-producer.properties: |
     key.serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -76,7 +76,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-sink-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   - apiGroups:
       - "*"
@@ -109,7 +109,7 @@ metadata:
   name: knative-kafka-sink-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 ---
 
@@ -132,7 +132,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-sink-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-sink-data-plane
@@ -165,7 +165,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -175,7 +175,7 @@ spec:
       name: kafka-sink-receiver
       labels:
         app: kafka-sink-receiver
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -199,7 +199,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kafka-sink-receiver
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-receiver
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-receiver
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -317,7 +317,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     app: kafka-sink-receiver

--- a/openshift/release/artifacts/eventing-kafka-source.yaml
+++ b/openshift/release/artifacts/eventing-kafka-source.yaml
@@ -21,7 +21,7 @@ metadata:
   name: config-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   config-kafka-source-producer.properties: |
     key.serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -141,7 +141,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   - apiGroups:
       - "*"
@@ -174,7 +174,7 @@ metadata:
   name: knative-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 ---
 
@@ -197,7 +197,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-source-data-plane
@@ -230,7 +230,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-source-dispatcher
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -240,7 +240,7 @@ spec:
       name: kafka-source-dispatcher
       labels:
         app: kafka-source-dispatcher
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -264,7 +264,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kafka-source-dispatcher
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-dispatcher
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-dispatcher
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config

--- a/openshift/release/artifacts/eventing-kafka.yaml
+++ b/openshift/release/artifacts/eventing-kafka.yaml
@@ -21,7 +21,7 @@ metadata:
   name: kafka-broker-config
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   default.topic.partitions: "10"
   default.topic.replication.factor: "3"
@@ -48,7 +48,7 @@ metadata:
   labels:
     duck.knative.dev/addressable: "true"
     knative.dev/crd-install: "true"
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   group: eventing.knative.dev
   names:
@@ -318,7 +318,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: eventing-kafka-source-observer
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:
@@ -350,7 +350,7 @@ metadata:
   name: config-kafka-source-defaults
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
   annotations:
     knative.dev/example-checksum: "b6ed351d"
 data:
@@ -411,7 +411,7 @@ metadata:
   name: kafka-channel-config
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"
 ---
@@ -703,7 +703,7 @@ metadata:
   name: config-kafka-descheduler
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
     predicates: |+
                     []
@@ -752,7 +752,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
   name: config-kafka-leader-election
   namespace: knative-eventing
   annotations:
@@ -818,7 +818,7 @@ metadata:
   name: config-kafka-scheduler
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
     predicates: |+
                   [
@@ -860,7 +860,7 @@ metadata:
   name: kafka-config-logging
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   config.xml: |
     <configuration>
@@ -891,7 +891,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-kafka-addressable-resolver
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -934,7 +934,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channelable-manipulator
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
@@ -974,7 +974,7 @@ kind: ClusterRole
 metadata:
   name: kafka-controller
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   - apiGroups:
       - "*"
@@ -1177,7 +1177,7 @@ metadata:
   name: kafka-controller
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 ---
 
@@ -1200,7 +1200,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -1216,7 +1216,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller-addressable-resolver
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -1249,7 +1249,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -1259,7 +1259,7 @@ spec:
       name: kafka-controller
       labels:
         app: kafka-controller
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1285,7 +1285,7 @@ spec:
 
       containers:
         - name: controller
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-kafka-controller
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-kafka-controller
           imagePullPolicy: IfNotPresent
           env:
             - name: BROKER_DATA_PLANE_CONFIG_MAP_NAMESPACE
@@ -1424,7 +1424,7 @@ kind: ClusterRole
 metadata:
   name: kafka-webhook-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:
@@ -1536,7 +1536,7 @@ metadata:
   name: kafka-webhook-eventing
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 ---
 
@@ -1559,7 +1559,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-webhook-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: kafka-webhook-eventing
@@ -1589,7 +1589,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 webhooks:
   - admissionReviewVersions: [ "v1", "v1beta1" ]
     clientConfig:
@@ -1620,7 +1620,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: pods.defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 webhooks:
   # Dispatcher pods webhook config.
   - admissionReviewVersions: [ "v1", "v1beta1" ]
@@ -1662,7 +1662,7 @@ metadata:
   name: kafka-webhook-eventing-certs
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -1684,7 +1684,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kafka.eventing.knative.dev
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -1717,7 +1717,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -1726,7 +1726,7 @@ spec:
     metadata:
       labels:
         app: kafka-webhook-eventing
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -1747,7 +1747,7 @@ spec:
         - name: kafka-webhook-eventing
           terminationMessagePolicy: FallbackToLogsOnError
 
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-webhook-kafka
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-webhook-kafka
 
           resources:
             requests:
@@ -1812,7 +1812,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   ports:
     - name: https-webhook
@@ -1845,7 +1845,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   - apiGroups:
       - apps
@@ -2052,7 +2052,7 @@ metadata:
   name: knative-kafka-controller-post-install
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -2073,7 +2073,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   # Storage version upgrader needs to be able to patch CRDs.
   - apiGroups:
@@ -2142,7 +2142,7 @@ metadata:
   name: knative-kafka-storage-version-migrator
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 
 ---
 
@@ -2151,7 +2151,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-storage-version-migrator
@@ -2182,7 +2182,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-controller-post-install
@@ -2213,7 +2213,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller-post-install
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -2221,7 +2221,7 @@ spec:
     metadata:
       labels:
         app: kafka-controller-post-install
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -2229,7 +2229,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: post-install
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-post-install
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-post-install
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -2259,7 +2259,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: "knative-kafka-storage-version-migrator"
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -2267,7 +2267,7 @@ spec:
     metadata:
       labels:
         app: "knative-kafka-storage-version-migrator"
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -2275,7 +2275,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-migrate
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-migrate
           env:
             - name: IGNORE_NOT_FOUND
               value: "true"
@@ -2305,7 +2305,7 @@ metadata:
   name: config-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   config-kafka-source-producer.properties: |
     key.serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -2425,7 +2425,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   - apiGroups:
       - "*"
@@ -2458,7 +2458,7 @@ metadata:
   name: knative-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 ---
 
@@ -2481,7 +2481,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-source-data-plane
@@ -2514,7 +2514,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-source-dispatcher
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -2524,7 +2524,7 @@ spec:
       name: kafka-source-dispatcher
       labels:
         app: kafka-source-dispatcher
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -2548,7 +2548,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kafka-source-dispatcher
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-dispatcher
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-dispatcher
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -2680,7 +2680,7 @@ metadata:
   name: config-kafka-broker-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   config-kafka-broker-producer.properties: |
     key.serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -2800,7 +2800,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-broker-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   - apiGroups:
       - "*"
@@ -2833,7 +2833,7 @@ metadata:
   name: knative-kafka-broker-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 ---
 
@@ -2856,7 +2856,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-broker-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-broker-data-plane
@@ -2889,7 +2889,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-dispatcher
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -2899,7 +2899,7 @@ spec:
       name: kafka-broker-dispatcher
       labels:
         app: kafka-broker-dispatcher
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -2923,7 +2923,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kafka-broker-dispatcher
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-dispatcher
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-dispatcher
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -3056,7 +3056,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -3066,7 +3066,7 @@ spec:
       name: kafka-broker-receiver
       labels:
         app: kafka-broker-receiver
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -3090,7 +3090,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kafka-broker-receiver
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-receiver
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-receiver
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -3208,7 +3208,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     app: kafka-broker-receiver
@@ -3249,7 +3249,7 @@ metadata:
   name: config-kafka-channel-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   config-kafka-channel-producer.properties: |
     key.serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -3368,7 +3368,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channel-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   - apiGroups:
       - "*"
@@ -3401,7 +3401,7 @@ metadata:
   name: knative-kafka-channel-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 ---
 
@@ -3424,7 +3424,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-channel-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-channel-data-plane
@@ -3457,7 +3457,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-dispatcher
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -3467,7 +3467,7 @@ spec:
       name: kafka-channel-dispatcher
       labels:
         app: kafka-channel-dispatcher
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -3491,7 +3491,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kafka-channel-dispatcher
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-dispatcher
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-dispatcher
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -3624,7 +3624,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-receiver
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -3634,7 +3634,7 @@ spec:
       name: kafka-channel-receiver
       labels:
         app: kafka-channel-receiver
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -3658,7 +3658,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kafka-channel-receiver
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-receiver
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-receiver
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -3776,7 +3776,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-receiver
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     app: kafka-channel-receiver
@@ -3817,7 +3817,7 @@ metadata:
   name: config-kafka-sink-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 data:
   config-kafka-sink-producer.properties: |
     key.serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -3872,7 +3872,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-sink-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 rules:
   - apiGroups:
       - "*"
@@ -3905,7 +3905,7 @@ metadata:
   name: knative-kafka-sink-data-plane
   namespace: knative-eventing
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 ---
 ---
 
@@ -3928,7 +3928,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-sink-data-plane
   labels:
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-sink-data-plane
@@ -3961,7 +3961,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     matchLabels:
@@ -3971,7 +3971,7 @@ spec:
       name: kafka-sink-receiver
       labels:
         app: kafka-sink-receiver
-        kafka.eventing.knative.dev/release: v1.4.0
+        kafka.eventing.knative.dev/release: v1.4
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes and zones.
       topologySpreadConstraints:
@@ -3995,7 +3995,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: kafka-sink-receiver
-          image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-receiver
+          image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-receiver
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config
@@ -4113,7 +4113,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    kafka.eventing.knative.dev/release: v1.4.0
+    kafka.eventing.knative.dev/release: v1.4
 spec:
   selector:
     app: kafka-sink-receiver

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 source $(dirname $0)/resolve.sh
 
 GITHUB_ACTIONS=true $(dirname $0)/../../hack/update-codegen.sh
-git apply openshift/patches/*
+git apply openshift/patches/close_offsetmanager.patch
+git apply openshift/patches/disable-ko-publish-rekt.patch
+git apply openshift/patches/override-min-version.patch
+git apply openshift/patches/use_kafkacat_from_ocp.patch
 
 # Eventing core will bring the config tracing ConfigMap, so remove it from heret
 rm -f control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml

--- a/vendor/knative.dev/eventing/test/rekt/resources/containersource/containersource.yaml
+++ b/vendor/knative.dev/eventing/test/rekt/resources/containersource/containersource.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: heartbeats
-        image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-heartbeats
+        image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-heartbeats
         args:
         - --period=1
         env:

--- a/vendor/knative.dev/eventing/test/rekt/resources/eventlibrary/eventlibrary.yaml
+++ b/vendor/knative.dev/eventing/test/rekt/resources/eventlibrary/eventlibrary.yaml
@@ -23,7 +23,7 @@ spec:
   restartPolicy: "Never"
   containers:
     - name: library
-      image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-event-library
+      image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-event-library
       imagePullPolicy: "IfNotPresent"
 
 ---

--- a/vendor/knative.dev/eventing/test/rekt/resources/flaker/flaker.yaml
+++ b/vendor/knative.dev/eventing/test/rekt/resources/flaker/flaker.yaml
@@ -23,7 +23,7 @@ spec:
   restartPolicy: "Never"
   containers:
     - name: flaker
-      image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-event-flaker
+      image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-event-flaker
       imagePullPolicy: "IfNotPresent"
       env:
         - name: "K_SINK"

--- a/vendor/knative.dev/eventing/test/test_images/event-sender/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/event-sender/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: event-sender
-      image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-event-sender
+      image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-event-sender
 

--- a/vendor/knative.dev/eventing/test/test_images/heartbeats/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/heartbeats/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: heartbeats
-      image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-heartbeats
+      image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-heartbeats
 

--- a/vendor/knative.dev/eventing/test/test_images/performance/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/performance/pod.yaml
@@ -8,5 +8,5 @@ metadata:
 spec:
   containers:
     - name: performance
-      image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-performance
+      image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-performance
 

--- a/vendor/knative.dev/eventing/test/test_images/print/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/print/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: helloworld
-      image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-print
+      image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-print
 

--- a/vendor/knative.dev/eventing/test/test_images/recordevents/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/recordevents/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: recordevents
-      image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-recordevents
+      image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-recordevents
 

--- a/vendor/knative.dev/eventing/test/test_images/request-sender/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/request-sender/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: request-sender
-      image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-request-sender
+      image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-request-sender
 

--- a/vendor/knative.dev/eventing/test/test_images/wathola-fetcher/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/wathola-fetcher/pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
     - name: wathola-fetcher
-      image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-wathola-fetcher
+      image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-wathola-fetcher

--- a/vendor/knative.dev/eventing/test/test_images/wathola-forwarder/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/wathola-forwarder/pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
     - name: wathola-forwarder
-      image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-wathola-forwarder
+      image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-wathola-forwarder

--- a/vendor/knative.dev/eventing/test/test_images/wathola-receiver/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/wathola-receiver/pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
     - name: wathola-receiver
-      image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-wathola-receiver
+      image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-wathola-receiver

--- a/vendor/knative.dev/eventing/test/test_images/wathola-sender/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/wathola-sender/pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
     - name: wathola-sender
-      image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-wathola-sender
+      image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-wathola-sender

--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
+++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
@@ -24,7 +24,7 @@ spec:
   restartPolicy: "Never"
   containers:
     - name: eventshub
-      image: registry.ci.openshift.org/openshift/knative-v1.4.0:knative-eventing-kafka-broker-test-eventshub
+      image: registry.ci.openshift.org/openshift/knative-v1.4:knative-eventing-kafka-broker-test-eventshub
       imagePullPolicy: "IfNotPresent"
       {{ if .withReadiness }}
       readinessProbe:


### PR DESCRIPTION
`config-tracing` is removed during the make generate-release command
since it will come from eventing core, so `./hack/update-checksum.sh`
fails since it can find the YAML.