### PR TITLE
[main] Do not generate checksum for config tracing

### DIFF
--- a/openshift/patches/remove_checksum_generation_for_config_tracing.patch
+++ b/openshift/patches/remove_checksum_generation_for_config_tracing.patch
@@ -1,0 +1,12 @@
+diff --git a/hack/update-checksums.sh b/hack/update-checksums.sh
+index ad2c6310..484dbeb5 100755
+--- a/hack/update-checksums.sh
++++ b/hack/update-checksums.sh
+@@ -26,7 +26,6 @@ fi
+ 
+ source $(dirname $0)/../vendor/knative.dev/hack/library.sh
+ 
+-go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml
+ go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/control-plane/config/eventing-kafka-broker/200-controller/100-config-logging.yaml
+ go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-leader-election.yaml
+ go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 source $(dirname $0)/resolve.sh
 
 GITHUB_ACTIONS=true $(dirname $0)/../../hack/update-codegen.sh
-git apply openshift/patches/*
+git apply openshift/patches/disable-ko-publish-rekt.patch
+git apply openshift/patches/override-min-version.patch
+git apply openshift/patches/use_kafkacat_from_ocp.patch
 
 # Eventing core will bring the config tracing ConfigMap, so remove it from heret
 rm -f control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift-knative/eventing-kafka-broker/pull/353

`config-tracing` is removed during the make generate-release command
since it will come from eventing core, so `./hack/update-checksum.sh`
fails since it can find the YAML.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>