### PR TITLE
[release-v1.4] Allow enabling data plane server and client metrics (#2436)

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/metrics/Metrics.java
@@ -40,7 +40,6 @@ import org.apache.kafka.clients.producer.Producer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -144,13 +143,9 @@ public class Metrics {
    */
   public static MetricsOptions getOptions(final BaseEnv metricsConfigs) {
     final var registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-    return new MicrometerMetricsOptions()
+    final var options = new MicrometerMetricsOptions()
       .setEnabled(true)
-      .addDisabledMetricsCategory(MetricsDomain.HTTP_CLIENT)
-      .addDisabledMetricsCategory(MetricsDomain.HTTP_SERVER)
       .addDisabledMetricsCategory(MetricsDomain.VERTICLES)
-      .addDisabledMetricsCategory(MetricsDomain.NET_CLIENT)
-      .addDisabledMetricsCategory(MetricsDomain.NET_SERVER)
       .addDisabledMetricsCategory(MetricsDomain.EVENT_BUS)
       .addDisabledMetricsCategory(MetricsDomain.DATAGRAM_SOCKET)
       // NAMED_POOL allocates a lot, so disable it.
@@ -173,6 +168,17 @@ public class Metrics {
         .setStartEmbeddedServer(true)
         .setEnabled(true)
       );
+
+    if (!metricsConfigs.isMetricsHTTPClientEnabled()) {
+      options.addDisabledMetricsCategory(MetricsDomain.HTTP_CLIENT);
+      options.addDisabledMetricsCategory(MetricsDomain.NET_CLIENT);
+    }
+    if (!metricsConfigs.isMetricsHTTPServerEnabled()) {
+      options.addDisabledMetricsCategory(MetricsDomain.HTTP_SERVER);
+      options.addDisabledMetricsCategory(MetricsDomain.NET_SERVER);
+    }
+
+    return options;
   }
 
   /**

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/BaseEnv.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/utils/BaseEnv.java
@@ -39,6 +39,12 @@ public class BaseEnv {
   public static final String METRICS_JVM_ENABLED = "METRICS_JVM_ENABLED";
   private final boolean metricsJvmEnabled;
 
+  public static final String METRICS_HTTP_CLIENT_ENABLED = "METRICS_HTTP_CLIENT_ENABLED";
+  private final boolean metricsHTTPClientEnabled;
+
+  public static final String METRICS_HTTP_SERVER_ENABLED = "METRICS_HTTP_SERVER_ENABLED";
+  private final boolean metricsHTTPServerEnabled;
+
   public static final String CONFIG_TRACING_PATH = "CONFIG_TRACING_PATH";
   private final String configTracingPath;
 
@@ -50,6 +56,8 @@ public class BaseEnv {
     this.metricsPort = Integer.parseInt(requireNonNull(envProvider.apply(METRICS_PORT)));
     this.metricsPublishQuantiles = Boolean.parseBoolean(envProvider.apply(METRICS_PUBLISH_QUANTILES));
     this.metricsJvmEnabled = Boolean.parseBoolean(envProvider.apply(METRICS_JVM_ENABLED));
+    this.metricsHTTPClientEnabled = Boolean.parseBoolean(envProvider.apply(METRICS_HTTP_CLIENT_ENABLED));
+    this.metricsHTTPServerEnabled = Boolean.parseBoolean(envProvider.apply(METRICS_HTTP_SERVER_ENABLED));
     this.producerConfigFilePath = requireNonNull(envProvider.apply(PRODUCER_CONFIG_FILE_PATH));
     this.dataPlaneConfigFilePath = requireNonNull(envProvider.apply(DATA_PLANE_CONFIG_FILE_PATH));
     this.configTracingPath = requireNonNull(envProvider.apply(CONFIG_TRACING_PATH));
@@ -78,6 +86,14 @@ public class BaseEnv {
 
   public boolean isMetricsJvmEnabled() {
     return metricsJvmEnabled;
+  }
+
+  public boolean isMetricsHTTPClientEnabled() {
+    return metricsHTTPClientEnabled;
+  }
+
+  public boolean isMetricsHTTPServerEnabled() {
+    return metricsHTTPServerEnabled;
   }
 
   public String getConfigTracingPath() {

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/utils/BaseEnvTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/utils/BaseEnvTest.java
@@ -31,7 +31,7 @@ public class BaseEnvTest {
     case "CONFIG_TRACING_PATH" -> "/etc/tracing";
     case "METRICS_JVM_ENABLED" -> "false";
     case "WAIT_STARTUP_SECONDS" -> "1";
-    default -> throw new IllegalArgumentException("unknown " + s);
+    default -> null;
   };
 
   @Test
@@ -72,5 +72,17 @@ public class BaseEnvTest {
   public void shouldGetJvmMetricsEnabled() {
     final var metricsConfigs = new BaseEnv(provider);
     assertThat(metricsConfigs.isMetricsJvmEnabled()).isFalse();
+  }
+
+  @Test
+  public void shouldGetHttpClientMetricsDisabled() {
+    final var metricsConfigs = new BaseEnv(provider);
+    assertThat(metricsConfigs.isMetricsHTTPClientEnabled()).isFalse();
+  }
+
+  @Test
+  public void shouldGetHttpServerMetricsDisabled() {
+    final var metricsConfigs = new BaseEnv(provider);
+    assertThat(metricsConfigs.isMetricsHTTPServerEnabled()).isFalse();
   }
 }

--- a/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverEnvTest.java
+++ b/data-plane/receiver/src/test/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverEnvTest.java
@@ -48,7 +48,7 @@ class ReceiverEnvTest {
         case BaseEnv.CONFIG_TRACING_PATH -> TRACING_CONFIG_PATH;
         case BaseEnv.METRICS_JVM_ENABLED -> METRICS_JVM_ENABLED;
         case BaseEnv.WAIT_STARTUP_SECONDS -> Integer.valueOf(WAIT_STARTUP_SECONDS).toString();
-        default -> throw new IllegalArgumentException(key);
+        default -> null;
       }
     );
 


### PR DESCRIPTION
Cherry-pick of https://github.com/knative-sandbox/eventing-kafka-broker/commit/79e2c2ac703640f1e600f78a2f5d8e9539aa66d7

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
