### PR TITLE
[release-v1.3] SendN sends events in a common t.Run

### DIFF
--- a/test/pkg/addressable/send.go
+++ b/test/pkg/addressable/send.go
@@ -47,34 +47,30 @@ func SendN(t *testing.T, n int, addressable Addressable, mutators ...EventMutato
 		wg.Add(n)
 
 		for i := 0; i < n; i++ {
+			// Client isn't thread safe so we need to create one per Goroutine.
+			go func(i int) {
+				client, err := testlib.NewClient(
+					addressable.Namespace,
+					t,
+				)
+				assert.Nil(t, err, fmt.Sprintf("event #%d", i))
 
-			t.Run(fmt.Sprintf("send event %d", i), func(t *testing.T) {
-				// Client isn't thread safe so we need to create one per Goroutine.
-				go func(i int) {
+				event := cetest.FullEvent()
+				id := uuid.New().String()
+				event.SetID(id)
 
-					client, err := testlib.NewClient(
-						addressable.Namespace,
-						t,
-					)
-					assert.Nil(t, err)
+				for _, mutator := range mutators {
+					mutator(&event)
+				}
 
-					event := cetest.FullEvent()
-					id := uuid.New().String()
-					event.SetID(id)
+				client.Namespace = addressable.Namespace
 
-					for _, mutator := range mutators {
-						mutator(&event)
-					}
+				name := names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-%d", addressable.Name, i))
+				client.SendEventToAddressable(ctx, name, addressable.Name, &addressable.TypeMeta, event)
 
-					client.Namespace = addressable.Namespace
-
-					name := names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-%d", addressable.Name, i))
-					client.SendEventToAddressable(ctx, name, addressable.Name, &addressable.TypeMeta, event)
-
-					idsChan <- event.ID()
-					wg.Done()
-				}(i)
-			})
+				idsChan <- event.ID()
+				wg.Done()
+			}(i)
 		}
 
 		wg.Wait()


### PR DESCRIPTION
Backport of https://github.com/knative-sandbox/eventing-kafka-broker/pull/2421

Running them in separate t.Run functions causes issues such as the
following one because events might be sent after the t.Run ends since
they run in separate go routines in background:

panic: Fail in goroutine after
TestKafkaSinkV1Alpha1AuthPlaintext/1/send_event_0 has completed

goroutine 6809 [running]:
testing.(*common).Fail(0xc002b5c340)
	/root/.gvm/gos/go1.17.8/src/testing/testing.go:710 +0x1b4
testing.(*common).FailNow(0xc002b5c340)
	/root/.gvm/gos/go1.17.8/src/testing/testing.go:732 +0x2f
testing.(*common).Fatalf(0xc00437a000, {0x2b71c16, 0x22}, {0xc004acfbd8,
0x3, 0x3})
	/root/.gvm/gos/go1.17.8/src/testing/testing.go:830 +0x85
knative.dev/eventing/test/lib.(*Client).SendEvent(0xc0035c2d20,
{0x3137bb0, 0xc0000e0008}, {0xc004096420, 0x11}, {0xc00437a000, 0x56},
{{0x319fac0, 0xc0031adce0}, {0xc0040af158, ...}, ...}, ...)

/root/.gvm/pkgsets/go1.17.8/global/src/knative.dev/eventing-kafka-broker/vendor/knative.dev/eventing/test/lib/send_event.go:63
+0x525
knative.dev/eventing/test/lib.(*Client).SendEventToAddressable(0xc0035c2d20,
{0x3137bb0, 0xc0000e0008}, {0xc004096420, 0x11}, {0x2b4f151, 0xa},
0xc00374f2a0, {{0x319fac0, 0xc0031adce0}, ...}, ...)

/root/.gvm/pkgsets/go1.17.8/global/src/knative.dev/eventing-kafka-broker/vendor/knative.dev/eventing/test/lib/send_event.go:45
+0x1fb
knative.dev/eventing-kafka-broker/test/pkg/addressable.SendN.func1.1.1(0x0)

/root/.gvm/pkgsets/go1.17.8/global/src/knative.dev/eventing-kafka-broker/test/pkg/addressable/send.go:72
+0x5cd