### PR TITLE
[1.4] Set TerminationMessagePolicy=FallbackToLogsOnError for partition-replication-factor-verifier so that we can see the failure in the pod status

### DIFF
--- a/test/pkg/kafka/verify_num_partitions_replication.go
+++ b/test/pkg/kafka/verify_num_partitions_replication.go
@@ -66,9 +66,10 @@ func VerifyNumPartitionAndReplicationFactor(
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:            name,
-							Image:           pkgtest.ImagePath(partitionReplicationVerifierImage),
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							Name:                     name,
+							Image:                    pkgtest.ImagePath(partitionReplicationVerifierImage),
+							ImagePullPolicy:          corev1.PullIfNotPresent,
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 							Env: []corev1.EnvVar{
 								{
 									Name:  "BOOTSTRAP_SERVERS",


### PR DESCRIPTION
Set TerminationMessagePolicy=FallbackToLogsOnError for partition-replication-factor-verifier so that we can see the failure in the pod status

Backport https://github.com/knative-sandbox/eventing-kafka-broker/pull/2627