### PR TITLE
Remove noisy log lines "Nothing changed" at info level

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerImpl.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/reconciler/impl/ResourcesReconcilerImpl.java
@@ -125,14 +125,15 @@ public class ResourcesReconcilerImpl implements ResourcesReconciler {
       final var oldEgress = cachedEgress.getKey();
 
       if (resourceEquals(newResource, oldResource) && egressEquals(newEgress, oldEgress)) {
-        logger.info("Nothing changed for egress {} {} {} {}",
-          keyValue("id", newEgress.getUid()),
-          keyValue("consumerGroup", newEgress.getConsumerGroup()),
-          keyValue("destination", newEgress.getDestination()),
-          keyValue("contractGeneration", generation)
-        );
         return;
       }
+
+      logger.debug("Config changed for egress {} {} {} {}",
+        keyValue("id", newEgress.getUid()),
+        keyValue("consumerGroup", newEgress.getConsumerGroup()),
+        keyValue("destination", newEgress.getDestination()),
+        keyValue("contractGeneration", generation)
+      );
 
       futures.add(
         this.egressReconcilerListener.onUpdateEgress(newResource, newEgress)


### PR DESCRIPTION
When egress changes are detected log the egress info
at debug level instead of logging egresses that weren't
changed at info.

Cherry-pick of https://github.com/knative-sandbox/eventing-kafka-broker/pull/2652

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>