### PR TITLE
[release-v1.4] Include fips disabled flag

### DIFF
--- a/data-plane/config/broker/500-dispatcher.yaml
+++ b/data-plane/config/broker/500-dispatcher.yaml
@@ -118,6 +118,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/data-plane/config/broker/500-receiver.yaml
+++ b/data-plane/config/broker/500-receiver.yaml
@@ -119,6 +119,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/data-plane/config/brokerv2/500-dispatcher.yaml
+++ b/data-plane/config/brokerv2/500-dispatcher.yaml
@@ -121,6 +121,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
 

--- a/data-plane/config/channel/500-dispatcher.yaml
+++ b/data-plane/config/channel/500-dispatcher.yaml
@@ -118,6 +118,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/data-plane/config/channel/500-receiver.yaml
+++ b/data-plane/config/channel/500-receiver.yaml
@@ -119,6 +119,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/data-plane/config/channelv2/500-dispatcher.yaml
+++ b/data-plane/config/channelv2/500-dispatcher.yaml
@@ -121,6 +121,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
 

--- a/data-plane/config/sink/500-receiver.yaml
+++ b/data-plane/config/sink/500-receiver.yaml
@@ -119,6 +119,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/data-plane/config/sourcev2/500-dispatcher.yaml
+++ b/data-plane/config/sourcev2/500-dispatcher.yaml
@@ -121,6 +121,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
 

--- a/openshift/release/artifacts/eventing-kafka-broker.yaml
+++ b/openshift/release/artifacts/eventing-kafka-broker.yaml
@@ -328,6 +328,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)
@@ -496,6 +497,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/openshift/release/artifacts/eventing-kafka-channel.yaml
+++ b/openshift/release/artifacts/eventing-kafka-channel.yaml
@@ -327,6 +327,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)
@@ -495,6 +496,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/openshift/release/artifacts/eventing-kafka-sink.yaml
+++ b/openshift/release/artifacts/eventing-kafka-sink.yaml
@@ -263,6 +263,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)

--- a/openshift/release/artifacts/eventing-kafka.yaml
+++ b/openshift/release/artifacts/eventing-kafka.yaml
@@ -2997,6 +2997,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)
@@ -3165,6 +3166,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)
@@ -3566,6 +3568,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)
@@ -3734,6 +3737,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)
@@ -4071,6 +4075,7 @@ spec:
           args:
             - "-XX:+CrashOnOutOfMemoryError"
             - "-Dlogback.configurationFile=/etc/logging/config.xml"
+            - "-Dcom.redhat.fips=false"
             - "-jar"
             - "/app/app.jar"
           # TODO set resources (limits and requests)


### PR DESCRIPTION
For the 1.4 we may potentially also disable the FIPS check.

On purpose I am not adding a "patch" to the `openshift/patches` folder since hopefully we will soon have a base image, and we do not need this tweak.

However, for now, we should include, unfortunately like on older releases.