### PR TITLE
[release-v1.4] Github action for building multiarch test images

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,2 +1,2 @@
 # Use :nonroot base image for all containers
-defaultBaseImage: gcr.io/distroless/static:nonroot
+defaultBaseImage: registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,12 @@ test-reconciler:
 # Requires ko 0.2.0 or newer.
 test-images:
 	for img in $(TEST_IMAGES); do \
-		KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko build --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -B $$img ; \
+		KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko resolve --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -RBf $$img ; \
 	done
 .PHONY: test-images
 
 test-image-single:
-	KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko build --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -B test/test_images/$(IMAGE)
+	KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko resolve --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -RBf test/test_images/$(IMAGE)
 .PHONY: test-image-single
 
 # Run make DOCKER_REPO_OVERRIDE=<your_repo> test-e2e-local if test images are available

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,12 @@ GOOS=linux
 # Ignore errors if there are no images.
 CONTROL_PLANE_IMAGES=./control-plane/cmd/kafka-controller ./control-plane/cmd/webhook-kafka ./control-plane/cmd/post-install
 TEST_IMAGES=$(shell find ./test/test_images ./vendor/knative.dev/reconciler-test/cmd ./vendor/knative.dev/eventing/test/test_images -mindepth 1 -maxdepth 1 -type d 2> /dev/null)
-KO_DOCKER_REPO=${DOCKER_REPO_OVERRIDE}
 BRANCH=
 TEST=
 IMAGE=
+TEST_IMAGE_TAG=latest
+DOCKER_REPO_OVERRIDE=
+KO_FLAGS=
 
 # Guess location of openshift/release repo. NOTE: override this if it is not correct.
 OPENSHIFT=${CURDIR}/../../github.com/openshift/release
@@ -42,12 +44,12 @@ test-reconciler:
 # Requires ko 0.2.0 or newer.
 test-images:
 	for img in $(TEST_IMAGES); do \
-		ko resolve --tags=latest -RBf $$img ; \
+		KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko build --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -B $$img ; \
 	done
 .PHONY: test-images
 
 test-image-single:
-	ko resolve --tags=latest -RBf test/test_images/$(IMAGE)
+	KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko build --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -B test/test_images/$(IMAGE)
 .PHONY: test-image-single
 
 # Run make DOCKER_REPO_OVERRIDE=<your_repo> test-e2e-local if test images are available

--- a/openshift/workflows/multiarch-build.yaml
+++ b/openshift/workflows/multiarch-build.yaml
@@ -9,14 +9,11 @@ defaults:
   run:
     shell: bash
 
-env:
-  KO_FLAGS: "--platform=all --sbom=none"
-
 jobs:
   multiarch-build:
     name: Build multiarch test images
-    # Run this only if the pull request was merged. In that case it should be safe to
-    # run on pull_request_target event which has privileged access to the repository.
+    # Run this only after the pull request was merged. In that case it should be safe to
+    # run on pull_request_target event with privileged access to the repository and secrets.
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
@@ -30,7 +27,7 @@ jobs:
       - name: Setup ko
         uses: imjasonh/setup-ko@v0.6
         with:
-          version: v0.12.0 # ko version
+          version: v0.12.0
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -38,24 +35,24 @@ jobs:
           path: ./src/github.com/${{ github.repository }}
 
       - name: Correct GOPATH
+        working-directory: ${GOPATH}/src/github.com/${{ github.repository }}
         run: |
-          cd "${GOPATH}/src/github.com/${{ github.repository }}"
           module="$(head -n 1 go.mod | awk '{ print $2 }')"
           mkdir -p "${GOPATH}/src/${module}"
           mv "${GOPATH}/src/github.com/${{ github.repository }}" "${GOPATH}/src/${module}"
-
           echo "CANONICAL_GO_REPO=${GOPATH}/src/${module}" >> $GITHUB_ENV
 
       - name: Login to quay.io
         env:
-          quay_user: ${{ secrets QUAY_USER }}
+          quay_user: ${{ secrets.QUAY_USER }}
           quay_password: ${{ secrets.QUAY_PASSWORD }}
         run: |
           ko login -u="${quay_user}" -p="${quay_password}" quay.io
 
-      - name: Build and push images
+      - name: Build and push multiarch test images
+        working-directory: ${CANONICAL_GO_REPO}
         run: |
-          cd "${CANONICAL_GO_REPO}"
-          # TODO: Parse TEST_IMAGE_TAG from current branch
+          # Remove knative-v prefix and parse major and minor version
+          major_minor=$(echo ${GITHUB_BASE_REF#release-v} | awk -F \. '{printf "%d.%d", $1, $2}')
           make test-images DOCKER_REPO_OVERRIDE=quay.io/${{ github.repository }}/ \
-            KO_FLAGS="${{ KO_FLAGS }}" TEST_IMAGE_TAG=v1.4
+            KO_FLAGS="--platform=all --sbom=none" TEST_IMAGE_TAG=v${major_minor}

--- a/openshift/workflows/multiarch-build.yaml
+++ b/openshift/workflows/multiarch-build.yaml
@@ -19,7 +19,7 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-      - name: Set up Golang
+      - name: Setup Golang
         uses: actions/setup-go@v2
         with:
           go-version: 1.17.x
@@ -28,6 +28,11 @@ jobs:
         uses: imjasonh/setup-ko@v0.6
         with:
           version: v0.12.0
+
+      - name: Setup make
+        run: |
+          sudo apt-get update
+          sudo apt-get install make
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/openshift/workflows/multiarch-build.yaml
+++ b/openshift/workflows/multiarch-build.yaml
@@ -1,0 +1,61 @@
+name: Build multiarch images
+
+on:
+  pull_request_target:
+    types: [ closed ]
+    branches: [ 'release-v*' ]
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  KO_FLAGS: "--platform=all --sbom=none"
+
+jobs:
+  multiarch-build:
+    name: Build multiarch test images
+    # Run this only if the pull request was merged. In that case it should be safe to
+    # run on pull_request_target event which has privileged access to the repository.
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: ${{ github.workspace }}
+    steps:
+      - name: Set up Golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+
+      - name: Setup ko
+        uses: imjasonh/setup-ko@v0.6
+        with:
+          version: v0.12.0 # ko version
+
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          path: ./src/github.com/${{ github.repository }}
+
+      - name: Correct GOPATH
+        run: |
+          cd "${GOPATH}/src/github.com/${{ github.repository }}"
+          module="$(head -n 1 go.mod | awk '{ print $2 }')"
+          mkdir -p "${GOPATH}/src/${module}"
+          mv "${GOPATH}/src/github.com/${{ github.repository }}" "${GOPATH}/src/${module}"
+
+          echo "CANONICAL_GO_REPO=${GOPATH}/src/${module}" >> $GITHUB_ENV
+
+      - name: Login to quay.io
+        env:
+          quay_user: ${{ secrets QUAY_USER }}
+          quay_password: ${{ secrets.QUAY_PASSWORD }}
+        run: |
+          ko login -u="${quay_user}" -p="${quay_password}" quay.io
+
+      - name: Build and push images
+        run: |
+          cd "${CANONICAL_GO_REPO}"
+          # TODO: Parse TEST_IMAGE_TAG from current branch
+          make test-images DOCKER_REPO_OVERRIDE=quay.io/${{ github.repository }}/ \
+            KO_FLAGS="${{ KO_FLAGS }}" TEST_IMAGE_TAG=v1.4


### PR DESCRIPTION
* Use pull_request_target event to trigger this github action - it will work with the target repository instead of the forked repository where this PR is coming from (required for getting access to credentials
* Use `types: [ closed ]` together with `if: github.event.pull_request.merged == true` which will run the github action after this PR is merged (not before).
* The QUAY_USER and QUAY_TOKEN have already been set up in this github project
* Only specific actions are configured in this repo with this pattern: `openshift-knative/eventing-kafka-broker/openshift/workflows/*`. See https://github.com/openshift-knative/eventing-kafka-broker/settings/actions
