### PR TITLE
[release-v1.5] Add flag to avoid running first-event-delay test in SO since it is too slow

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -125,7 +125,9 @@ function run_conformance_tests() {
 }
 
 function run_e2e_new_tests() {
-  ./test/scripts/first-event-delay.sh || return $?
+  if [[ ${FIRST_EVENT_DELAY_ENABLED:-true} == true ]]; then
+    ./test/scripts/first-event-delay.sh || return $?
+  fi
   go_test_e2e -timeout=100m ./test/e2e_new/... || return $?
   go_test_e2e -timeout=100m ./test/e2e_new_channel/... || return $?
 }


### PR DESCRIPTION
I think there is no need to run this test in SO.
It takes to much time to complete and we're already running it in this repository.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>