### PR TITLE
[main] Use go install instead of deprecated go get

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -7,7 +7,7 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 
 RUN yum install -y kubectl httpd-tools
 
-RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
+RUN GO111MODULE=on go install github.com/mikefarah/yq/v3@latest
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
Fix the following error:
```
STEP 5/8: RUN GO111MODULE=on go get github.com/mikefarah/yq/v3
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>