### PR TITLE
[main] Add flag to avoid running first-event-delay test in SO since it is too slow

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -151,7 +151,9 @@ function run_conformance_tests() {
 function run_e2e_new_tests() {
   export BROKER_CLASS="Kafka"
 
-  ./test/scripts/first-event-delay.sh || return $?
+  if [[ ${FIRST_EVENT_DELAY_ENABLED:-true} == true ]]; then
+    ./test/scripts/first-event-delay.sh || return $?
+  fi
   go_test_e2e -timeout=100m ./test/e2e_new/... || return $?
   go_test_e2e -timeout=100m ./test/e2e_new_channel/... || return $?
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift-knative/eventing-kafka-broker/commit/35bf58b38ae705e82252b5cd57894e34f44551b7

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>