### PR TITLE
[main] Allow running rekt tests in namespace with enforced "restricted" pod security standard

### DIFF
--- a/openshift/patches/security-context-for-test-pods.patch
+++ b/openshift/patches/security-context-for-test-pods.patch
@@ -1,0 +1,235 @@
+diff --git a/vendor/knative.dev/pkg/test/security/security.go b/vendor/knative.dev/pkg/test/security/security.go
+new file mode 100644
+index 00000000..112601db
+--- /dev/null
++++ b/vendor/knative.dev/pkg/test/security/security.go
+@@ -0,0 +1,70 @@
++/*
++Copyright 2022 The Knative Authors
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package security
++
++import (
++	"context"
++
++	corev1 "k8s.io/api/core/v1"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/client-go/kubernetes"
++	"knative.dev/pkg/ptr"
++)
++
++var DefaultPodSecurityContext = corev1.PodSecurityContext{
++	RunAsNonRoot: ptr.Bool(true),
++	SeccompProfile: &corev1.SeccompProfile{
++		Type: corev1.SeccompProfileTypeRuntimeDefault,
++	},
++}
++
++var DefaultContainerSecurityContext = corev1.SecurityContext{
++	AllowPrivilegeEscalation: ptr.Bool(false),
++	Capabilities: &corev1.Capabilities{
++		Drop: []corev1.Capability{"ALL"},
++	},
++}
++
++// AllowRestrictedPodSecurityStandard adds SecurityContext to Pod and its containers so that it can run
++// in a namespace with enforced "restricted" security standard.
++func AllowRestrictedPodSecurityStandard(ctx context.Context, kubeClient kubernetes.Interface, pod *corev1.Pod) error {
++	enforced, err := IsRestrictedPodSecurityEnforced(ctx, kubeClient, pod.Namespace)
++	if err != nil {
++		return err
++	}
++	if enforced {
++		pod.Spec.SecurityContext = &DefaultPodSecurityContext
++		for _, c := range pod.Spec.Containers {
++			c.SecurityContext = &DefaultContainerSecurityContext
++		}
++	}
++	return nil
++}
++
++// IsRestrictedPodSecurityEnforced checks if the given namespace has enforced restricted security standard.
++func IsRestrictedPodSecurityEnforced(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (bool, error) {
++	ns, err := kubeClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
++	if err != nil {
++		return false, err
++	}
++	for k, v := range ns.Labels {
++		if k == "pod-security.kubernetes.io/enforce" && v == "restricted" {
++			return true, nil
++		}
++	}
++	return false, nil
++}
+diff --git a/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml b/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
+index 5dea70f1..1cc5d766 100644
+--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
++++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml
+@@ -22,8 +22,31 @@ metadata:
+ spec:
+   serviceAccountName: "{{ .namespace }}"
+   restartPolicy: "Never"
++  {{ if .podSecurityContext }}
++  securityContext:
++    runAsNonRoot: {{ .podSecurityContext.runAsNonRoot }}
++    seccompProfile:
++      type: {{ .podSecurityContext.seccompProfile.type }}
++  {{ end }}
+   containers:
+     - name: eventshub
++      {{ if .containerSecurityContext }}
++      securityContext:
++        capabilities:
++          {{ if .containerSecurityContext.capabilities.drop }}
++          drop:
++            {{ range $_, $value := .containerSecurityContext.capabilities.drop }}
++            - {{ $value }}
++            {{ end }}
++          {{ end }}
++          {{ if .containerSecurityContext.capabilities.add }}
++          add:
++            {{ range $_, $value := .containerSecurityContext.capabilities.add }}
++            - {{ $value }}
++            {{ end }}
++          {{ end }}
++        allowPrivilegeEscalation: {{ .containerSecurityContext.allowPrivilegeEscalation }}
++      {{ end }}
+       image: {{ .image }}
+       imagePullPolicy: "IfNotPresent"
+       {{ if .withReadiness }}
+diff --git a/vendor/knative.dev/reconciler-test/pkg/eventshub/resources.go b/vendor/knative.dev/reconciler-test/pkg/eventshub/resources.go
+index f1ab17a1..32a1a858 100644
+--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/resources.go
++++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/resources.go
+@@ -71,13 +71,17 @@ func Install(name string, options ...EventsHubOption) feature.StepFn {
+ 
+ 		isReceiver := strings.Contains(envs["EVENT_GENERATORS"], "receiver")
+ 
+-		// Deploy
+-		if _, err := manifest.InstallYamlFS(ctx, templates, map[string]interface{}{
++		cfg := map[string]interface{}{
+ 			"name":          name,
+ 			"envs":          envs,
+ 			"image":         ImageFromContext(ctx),
+ 			"withReadiness": isReceiver,
+-		}); err != nil {
++		}
++
++		manifest.PodSecurityCfgFn(ctx, t)(cfg)
++
++		// Deploy
++		if _, err := manifest.InstallYamlFS(ctx, templates, cfg); err != nil {
+ 			log.Fatal(err)
+ 		}
+ 
+diff --git a/vendor/knative.dev/reconciler-test/pkg/k8s/pod.go b/vendor/knative.dev/reconciler-test/pkg/k8s/pod.go
+index c1276a57..4f6422a8 100644
+--- a/vendor/knative.dev/reconciler-test/pkg/k8s/pod.go
++++ b/vendor/knative.dev/reconciler-test/pkg/k8s/pod.go
+@@ -26,6 +26,7 @@ import (
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/runtime"
+ 	"knative.dev/pkg/kmeta"
++	pkgsecurity "knative.dev/pkg/test/security"
+ )
+ 
+ func GetFirstTerminationMessage(pod *corev1.Pod) string {
+@@ -77,3 +78,35 @@ func PodReference(namespace string, name string) (corev1.ObjectReference, error)
+ 	pod.APIVersion, pod.Kind = kind.ToAPIVersionAndKind()
+ 	return kmeta.ObjectReference(pod), nil
+ }
++
++func WithDefaultPodSecurityContext(cfg map[string]interface{}) {
++	if _, set := cfg["podSecurityContext"]; !set {
++		cfg["podSecurityContext"] = map[string]interface{}{}
++	}
++	podSecurityContext := cfg["podSecurityContext"].(map[string]interface{})
++	podSecurityContext["runAsNonRoot"] = pkgsecurity.DefaultPodSecurityContext.RunAsNonRoot
++	podSecurityContext["seccompProfile"] = map[string]interface{}{}
++	seccompProfile := podSecurityContext["seccompProfile"].(map[string]interface{})
++	seccompProfile["type"] = pkgsecurity.DefaultPodSecurityContext.SeccompProfile.Type
++
++	if _, set := cfg["containerSecurityContext"]; !set {
++		cfg["containerSecurityContext"] = map[string]interface{}{}
++	}
++	containerSecurityContext := cfg["containerSecurityContext"].(map[string]interface{})
++	containerSecurityContext["allowPrivilegeEscalation"] =
++		pkgsecurity.DefaultContainerSecurityContext.AllowPrivilegeEscalation
++	containerSecurityContext["capabilities"] = map[string]interface{}{}
++	capabilities := containerSecurityContext["capabilities"].(map[string]interface{})
++	if len(pkgsecurity.DefaultContainerSecurityContext.Capabilities.Drop) != 0 {
++		capabilities["drop"] = []string{}
++		for _, drop := range pkgsecurity.DefaultContainerSecurityContext.Capabilities.Drop {
++			capabilities["drop"] = append(capabilities["drop"].([]string), string(drop))
++		}
++	}
++	if len(pkgsecurity.DefaultContainerSecurityContext.Capabilities.Add) != 0 {
++		capabilities["add"] = []string{}
++		for _, drop := range pkgsecurity.DefaultContainerSecurityContext.Capabilities.Drop {
++			capabilities["add"] = append(capabilities["add"].([]string), string(drop))
++		}
++	}
++}
+diff --git a/vendor/knative.dev/reconciler-test/pkg/manifest/options.go b/vendor/knative.dev/reconciler-test/pkg/manifest/options.go
+new file mode 100644
+index 00000000..6a9dcf78
+--- /dev/null
++++ b/vendor/knative.dev/reconciler-test/pkg/manifest/options.go
+@@ -0,0 +1,41 @@
++/*
++Copyright 2022 The Knative Authors
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package manifest
++
++import (
++	"context"
++
++	kubeclient "knative.dev/pkg/client/injection/kube/client"
++	pkgsecurity "knative.dev/pkg/test/security"
++	"knative.dev/reconciler-test/pkg/environment"
++	"knative.dev/reconciler-test/pkg/feature"
++	"knative.dev/reconciler-test/pkg/k8s"
++)
++
++// PodSecurityCfgFn returns a function for configuring security context for Pod, depending
++// on security settings of the enclosing namespace.
++func PodSecurityCfgFn(ctx context.Context, t feature.T) CfgFn {
++	namespace := environment.FromContext(ctx).Namespace()
++	restrictedMode, err := pkgsecurity.IsRestrictedPodSecurityEnforced(ctx, kubeclient.Get(ctx), namespace)
++	if err != nil {
++		t.Fatalf("Error while checking restricted pod security mode for namespace %s", namespace)
++	}
++	if restrictedMode {
++		return k8s.WithDefaultPodSecurityContext
++	}
++	return func(map[string]interface{}) {}
++}
+-- 
+2.37.3
+

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -8,6 +8,7 @@ GITHUB_ACTIONS=true $(dirname $0)/../../hack/update-codegen.sh
 git apply openshift/patches/disable-ko-publish-rekt.patch
 git apply openshift/patches/override-min-version.patch
 git apply openshift/patches/use_kafkacat_from_ocp.patch
+git apply openshift/patches/security-context-for-test-pods.patch
 
 # Eventing core will bring the config tracing ConfigMap, so remove it from heret
 rm -f control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml


### PR DESCRIPTION
The main branch only receives the patch, not the actual changes after applying it.