### PR TITLE
[main] Update k8s min version patch since it failed in the periodic update

### DIFF
--- a/openshift/patches/override-min-version.patch
+++ b/openshift/patches/override-min-version.patch
@@ -6,7 +6,7 @@ index 56b7ae95..c79f442d 100644
  	// NOTE: If you are changing this line, please also update the minimum kubernetes
  	// version listed here:
  	// https://github.com/knative/docs/blob/mkdocs/docs/snippets/prerequisites.md
--	defaultMinimumVersion = "v1.23.0"
+-	defaultMinimumVersion = "v1.24.0"
 +	defaultMinimumVersion = "v1.19.0"
  )
  


### PR DESCRIPTION
Error:
```
01:35:21  error: patch failed: vendor/knative.dev/pkg/version/version.go:33
01:35:21  error: vendor/knative.dev/pkg/version/version.go: patch does not apply
```

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>