### PR TITLE
[release-v1.5] backport topic Delete ACL to kafka users

### DIFF
--- a/test/kafka/user-sasl-scram-512.yaml
+++ b/test/kafka/user-sasl-scram-512.yaml
@@ -56,3 +56,10 @@ spec:
           name: "*"
         operation: Describe
         host: "*"
+      # Required ACL rule to be able to delete topics
+      # (Note: this is needed to be able to successfully delete KafkaChannel resources)
+      - resource:
+          type: topic
+          name: "*"
+        operation: Delete
+        host: "*"

--- a/test/kafka/user-tls.yaml
+++ b/test/kafka/user-tls.yaml
@@ -56,3 +56,10 @@ spec:
           name: "*"
         operation: Describe
         host: "*"
+      # Required ACL rule to be able to delete topics
+      # (Note: this is needed to be able to successfully delete KafkaChannel resources)
+      - resource:
+          type: topic
+          name: "*"
+        operation: Delete
+        host: "*"


### PR DESCRIPTION
backport the ACL part of https://github.com/knative-sandbox/eventing-kafka-broker/pull/2381 to release-v1.5

authorize kafka test users to delete topics, so that the testsuites can cleanup by themselves, 
