### PR TITLE
[release-v1.6] Source v2 pod version selector for upgrade

### DIFF
--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -604,7 +604,10 @@ func (r *Reconciler) isKEDAEnabled(ctx context.Context, namespace string) bool {
 }
 
 func (r Reconciler) ensureContractConfigmapsExist(ctx context.Context, scheduler Scheduler) error {
-	selector := labels.SelectorFromSet(map[string]string{"app": scheduler.StatefulSetName})
+	selector := labels.SelectorFromSet(map[string]string{
+		"app": scheduler.StatefulSetName,
+		"app-version": "v2",
+	})
 	pods, err := r.PodLister.
 		Pods(r.SystemNamespace).
 		List(selector)

--- a/data-plane/config/source/500-dispatcher.yaml
+++ b/data-plane/config/source/500-dispatcher.yaml
@@ -33,6 +33,7 @@ spec:
       name: kafka-source-dispatcher
       labels:
         app: kafka-source-dispatcher
+        app-version: v2
         app.kubernetes.io/component: kafka-dispatcher
         kafka.eventing.knative.dev/release: devel
     spec:

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	k8s.io/apiserver v0.25.2
 	k8s.io/client-go v0.25.2
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
-	sigs.k8s.io/yaml v1.3.0
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 require (

--- a/openshift/release/artifacts/eventing-kafka-source.yaml
+++ b/openshift/release/artifacts/eventing-kafka-source.yaml
@@ -282,6 +282,7 @@ spec:
       name: kafka-source-dispatcher
       labels:
         app: kafka-source-dispatcher
+        app-version: v2
         app.kubernetes.io/component: kafka-dispatcher
         kafka.eventing.knative.dev/release: v1.6
     spec:

--- a/openshift/release/artifacts/eventing-kafka.yaml
+++ b/openshift/release/artifacts/eventing-kafka.yaml
@@ -2823,6 +2823,7 @@ spec:
       name: kafka-source-dispatcher
       labels:
         app: kafka-source-dispatcher
+        app-version: v2
         app.kubernetes.io/component: kafka-dispatcher
         kafka.eventing.knative.dev/release: v1.6
     spec:


### PR DESCRIPTION
The pod lister lists old pods in addition to the statefulset
related ones because they have the same
`app: kafka-source-dispatcher` label.