### PR TITLE
[main] Add patch to skip namespaced broker propagation test

### DIFF
--- a/openshift/patches/skip_namespaced_broker_propagation_test.patch
+++ b/openshift/patches/skip_namespaced_broker_propagation_test.patch
@@ -1,0 +1,13 @@
+diff --git a/test/e2e_new/broker_test.go b/test/e2e_new/broker_test.go
+index 52f168a9f..1522c7ef8 100644
+--- a/test/e2e_new/broker_test.go
++++ b/test/e2e_new/broker_test.go
+@@ -117,6 +117,8 @@ func TestBrokerCannotReachKafkaCluster(t *testing.T) {
+ }
+ 
+ func TestNamespacedBrokerResourcesPropagation(t *testing.T) {
++	t.Skip("We propagate service monitors in Serverless Operator so this test won't work for now")
++
+ 	ctx, env := global.Environment(
+ 		knative.WithKnativeNamespace(system.Namespace()),
+ 		knative.WithLoggingConfig,


### PR DESCRIPTION
Here's the reason for this: https://github.com/openshift-knative/eventing-kafka-broker/pull/499

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>