### PR TITLE
[release-v1.7] Do not block finalization if secret for external topic is gone

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -386,14 +386,21 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 		return err
 	}
 
+	_, externalTopic := isExternalTopic(broker)
 	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: brokerConfig, UseNamespaceInConfigmap: false}, r.SecretProviderFunc())
 	if err != nil {
-		return fmt.Errorf("failed to get secret: %w", err)
+
+		if externalTopic {
+			// we don't care
+			return nil
+		} else {
+			return fmt.Errorf("failed to get secret: %w", err)
+		}
 	}
 
 	// External topics are not managed by the broker,
 	// therefore we do not delete them
-	_, externalTopic := isExternalTopic(broker)
+	//	_, externalTopic := isExternalTopic(broker)
 	if !externalTopic {
 
 		// I do not like the use of `_`


### PR DESCRIPTION
Partially porting fix for #2829 to OCP.

The "rek test" is missing, due to dependencies mismatch (will be present in 1.9). Reference PR for the base work:
https://github.com/knative/eventing/pull/6645