### PR TITLE
[release-v1.6 ]granting permissions to delete consumer groups metadata

### DIFF
--- a/test/kafka/user-sasl-scram-512.yaml
+++ b/test/kafka/user-sasl-scram-512.yaml
@@ -43,6 +43,11 @@ spec:
           patternType: literal
         operation: Read
         host: "*"
+      - resource:
+          type: group
+          name: "*"
+        operation: Delete
+        host: "*"
       # Example ACL rules for producing to topic knative-messaging-kafka
       - resource:
           type: topic

--- a/test/kafka/user-tls.yaml
+++ b/test/kafka/user-tls.yaml
@@ -43,6 +43,11 @@ spec:
           patternType: literal
         operation: Read
         host: "*"
+      - resource:
+          type: group
+          name: "*"
+        operation: Delete
+        host: "*"
       # Example ACL rules for producing to a topic.
       - resource:
           type: topic


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>


manual port of https://github.com/knative-sandbox/eventing-kafka-broker/commit/d13860c2aca6defc1ab860b4d9a4f2c82e07e768 to here