### PR TITLE
Update patch for kafkaCatImage

### DIFF
--- a/openshift/patches/use_kafkacat_from_ocp.patch
+++ b/openshift/patches/use_kafkacat_from_ocp.patch
@@ -1,13 +1,13 @@
-diff --git a/vendor/knative.dev/eventing-kafka/test/e2e/helpers/kafka_helper.go b/vendor/knative.dev/eventing-kafka/test/e2e/helpers/kafka_helper.go
-index f48c5708..9c750aba 100644
---- a/vendor/knative.dev/eventing-kafka/test/e2e/helpers/kafka_helper.go
-+++ b/vendor/knative.dev/eventing-kafka/test/e2e/helpers/kafka_helper.go
-@@ -51,7 +51,7 @@ const (
- 	strimziUserResource  = "kafkausers"
- 	interval             = 3 * time.Second
- 	timeout              = 4 * time.Minute
--	kafkaCatImage        = "docker.io/edenhill/kafkacat:1.6.0"
-+	kafkaCatImage        = "quay.io/openshift-knative/kafkacat:1.6.0"
+diff --git a/test/e2e_source/helpers/kafka_helper.go b/test/e2e_source/helpers/kafka_helper.go
+index a82e8ee1..f6b65123 100644
+--- a/test/e2e_source/helpers/kafka_helper.go
++++ b/test/e2e_source/helpers/kafka_helper.go
+@@ -52,7 +52,7 @@ const (
+        strimziUserResource  = "kafkausers"
+        interval             = 3 * time.Second
+        timeout              = 4 * time.Minute
+-       kafkaCatImage        = "docker.io/edenhill/kafkacat:1.6.0"
++       kafkaCatImage        = "quay.io/openshift-knative/kafkacat:1.6.0"
  )
-
+ 
  var (


### PR DESCRIPTION
Fix current CI issue (https://redhat-internal.slack.com/archives/C033PCUSA4X/p1673829335948609):

```
01:35:35  error: vendor/knative.dev/eventing-kafka/test/e2e/helpers/kafka_helper.go: No such file or directory
```
comes from https://github.com/knative-sandbox/eventing-kafka-broker/pull/2878 as the `kafka_helpers.go` file moved to another directory.