### PR TITLE
Fix patch for kafkaCatImage

### DIFF
--- a/openshift/patches/use_kafkacat_from_ocp.patch
+++ b/openshift/patches/use_kafkacat_from_ocp.patch
@@ -1,13 +1,13 @@
 diff --git a/test/e2e_source/helpers/kafka_helper.go b/test/e2e_source/helpers/kafka_helper.go
-index a82e8ee1..f6b65123 100644
+index 3b295492..7ddf1346 100644
 --- a/test/e2e_source/helpers/kafka_helper.go
 +++ b/test/e2e_source/helpers/kafka_helper.go
 @@ -52,7 +52,7 @@ const (
-        strimziUserResource  = "kafkausers"
-        interval             = 3 * time.Second
-        timeout              = 4 * time.Minute
--       kafkaCatImage        = "docker.io/edenhill/kafkacat:1.6.0"
-+       kafkaCatImage        = "quay.io/openshift-knative/kafkacat:1.6.0"
+ 	strimziUserResource  = "kafkausers"
+ 	interval             = 3 * time.Second
+ 	timeout              = 4 * time.Minute
+-	kafkaCatImage        = "docker.io/edenhill/kafkacat:1.6.0"
++	kafkaCatImage        = "quay.io/openshift-knative/kafkacat:1.6.0"
  )
  
  var (


### PR DESCRIPTION
Fix the kafkaCatImage patch to use tabs instead of spaces (copied the patch initially from console output :facepalm: )