### PR TITLE
Remove kafkacat patch from generate-release.sh

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -7,7 +7,6 @@ source $(dirname $0)/resolve.sh
 GITHUB_ACTIONS=true $(dirname $0)/../../hack/update-codegen.sh
 git apply openshift/patches/disable-ko-publish-rekt.patch
 git apply openshift/patches/override-min-version.patch
-git apply openshift/patches/use_kafkacat_from_ocp.patch
 
 # Eventing core will bring the config tracing ConfigMap, so remove it from heret
 rm -f control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml


### PR DESCRIPTION
Since the kafkacat patch is not specific to a files in vendor/ anymore, the changes will not be overwritten anymore and thus only needs to run once in the update-to-head.sh.