### PR TITLE
[release-v1.7] Backport 2910

### DIFF
--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -363,15 +363,13 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 		return nil
 	}
 
-	_, externalTopic := isExternalTopic(broker)
 	secret, err := security.Secret(ctx, &security.MTConfigMapSecretLocator{ConfigMap: brokerConfig, UseNamespaceInConfigmap: false}, r.SecretProviderFunc())
 	if err != nil {
-
-		if externalTopic {
-			// we don't care
-			return nil
-		} else {
-			return fmt.Errorf("failed to get secret: %w", err)
+		// If we can not get the referenced secret,
+		// let us try for a bit before we give up.
+		brokerUUID := string(broker.GetUID())
+		if r.Counter.Inc(brokerUUID) <= 5 {
+			return controller.NewRequeueAfter(5 * time.Second)
 		}
 	}
 
@@ -386,7 +384,7 @@ func (r *Reconciler) finalizeKind(ctx context.Context, broker *eventing.Broker) 
 
 	// External topics are not managed by the broker,
 	// therefore we do not delete them
-	//	_, externalTopic := isExternalTopic(broker)
+	_, externalTopic := isExternalTopic(broker)
 	if !externalTopic {
 		topicConfig, err := r.topicConfig(logger, broker, brokerConfig)
 		if err != nil {

--- a/control-plane/pkg/reconciler/broker/broker_test.go
+++ b/control-plane/pkg/reconciler/broker/broker_test.go
@@ -22,6 +22,8 @@ import (
 	"net/url"
 	"testing"
 
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/counter"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"k8s.io/utils/pointer"
@@ -2179,7 +2181,8 @@ func brokerFinalization(t *testing.T, format string, env config.Env) {
 					"annotation_to_preserve": "value_to_preserve",
 				}),
 			},
-			Key: testKey,
+			Key:     testKey,
+			WantErr: true,
 			WantUpdates: []clientgotesting.UpdateActionImpl{
 				ConfigMapUpdate(env.DataPlaneConfigMapNamespace, env.ContractConfigMapName, env.ContractConfigMapFormat, &contract.Contract{
 					Resources:  []*contract.Resource{},
@@ -2427,8 +2430,9 @@ func useTable(t *testing.T, table TableTest, env *config.Env) {
 					T:                                      t,
 				}, nil
 			},
-			Env:    env,
-			Prober: proberMock,
+			Env:     env,
+			Prober:  proberMock,
+			Counter: counter.NewExpiringCounter(ctx),
 		}
 
 		reconciler.Tracker = &FakeTracker{}

--- a/test/e2e_new/broker_test.go
+++ b/test/e2e_new/broker_test.go
@@ -84,6 +84,22 @@ func TestBrokerConfigMapDoesNotExist(t *testing.T) {
 	env.Test(ctx, t, features.BrokerConfigMapDoesNotExist())
 }
 
+func TestBrokerAuthSecretForInternalTopicDoesNotExist(t *testing.T) {
+	// this test is observed to flake more when it is parallel
+	// t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.WithPollTimings(PollInterval, PollTimeout),
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, features.BrokerAuthSecretForInternalTopicDoesNotExist())
+}
+
 func TestTriggerLatestOffset(t *testing.T) {
 	// this test is observed to flake more when it is parallel
 	// t.Parallel()

--- a/test/e2e_new/features/broker_deleted_recreated.go
+++ b/test/e2e_new/features/broker_deleted_recreated.go
@@ -97,6 +97,32 @@ func BrokerConfigMapDoesNotExist() *feature.Feature {
 	return f
 }
 
+// BrokerAuthSecretForInternalTopicDoesNotExist tests that a broker can be deleted without the Secret.
+func BrokerAuthSecretForInternalTopicDoesNotExist() *feature.Feature {
+	f := feature.NewFeatureNamed("delete broker with non existing Secret or Topic")
+
+	brokerName := feature.MakeRandomK8sName("broker")
+	configName := feature.MakeRandomK8sName("config")
+
+	f.Setup("create broker config", brokerconfigmap.Install(
+		configName,
+		brokerconfigmap.WithBootstrapServer(testpkg.BootstrapServersSsl),
+		brokerconfigmap.WithAuthSecret("does-not-exist"),
+		brokerconfigmap.WithNumPartitions(1),
+		brokerconfigmap.WithReplicationFactor(1),
+	))
+
+	f.Setup("install broker", broker.Install(
+		brokerName,
+		append(
+			broker.WithEnvConfig(),
+			broker.WithConfig(configName))...))
+
+	f.Assert("delete broker", featuressteps.DeleteBroker(brokerName))
+
+	return f
+}
+
 // BrokerCannotReachKafkaCluster tests that a broker can be deleted even when KafkaCluster is unreachable.
 func BrokerCannotReachKafkaCluster() *feature.Feature {
 	f := feature.NewFeatureNamed("delete broker with unreachable Kafka cluster")

--- a/test/e2e_new/resources/configmap/broker/broker_config.go
+++ b/test/e2e_new/resources/configmap/broker/broker_config.go
@@ -61,3 +61,8 @@ func WithBootstrapServer(bootstrapServer string) manifest.CfgFn {
 		cfg["bootstrapServer"] = bootstrapServer
 	}
 }
+func WithAuthSecret(authSecret string) manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["authSecret"] = authSecret
+	}
+}

--- a/test/e2e_new/resources/configmap/broker/broker_config.yaml
+++ b/test/e2e_new/resources/configmap/broker/broker_config.yaml
@@ -27,3 +27,6 @@ data:
   {{ if .replicationFactor }}
   default.topic.replication.factor: "{{ .replicationFactor }}"
   {{ end }}
+  {{ if .authSecret }}
+  auth.secret.ref.name: "{{ .authSecret }}"
+  {{ end }}


### PR DESCRIPTION
Backporting upstream #2910
and adding rekt-test missing parts (`with auth secret`) 




