### PR TITLE
[release-v1.7] Fix evictor panic

### DIFF
--- a/control-plane/pkg/reconciler/consumergroup/evictor.go
+++ b/control-plane/pkg/reconciler/consumergroup/evictor.go
@@ -134,7 +134,7 @@ func (e *evictor) disablePodScheduling(logger *zap.Logger, pod *corev1.Pod) erro
 }
 
 func removePlacement(before []eventingduckv1alpha1.Placement, toRemove *eventingduckv1alpha1.Placement) []eventingduckv1alpha1.Placement {
-	after := make([]eventingduckv1alpha1.Placement, 0, len(before)-1)
+	after := make([]eventingduckv1alpha1.Placement, 0, len(before))
 	for _, p := range before {
 		if p.PodName != toRemove.PodName {
 			after = append(after, p)

--- a/control-plane/pkg/reconciler/consumergroup/evictor_test.go
+++ b/control-plane/pkg/reconciler/consumergroup/evictor_test.go
@@ -76,6 +76,40 @@ func TestEvictorEvictSuccess(t *testing.T) {
 	require.Nil(t, err)
 }
 
+func TestEvictorNoEvictionEmptyPlacement(t *testing.T) {
+	ctx, _ := reconcilertesting.SetupFakeContext(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "name"},
+	}
+
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "name1"},
+	}
+
+	cg := &kafkainternals.ConsumerGroup{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: "cg-name"},
+		Status: kafkainternals.ConsumerGroupStatus{
+			PlaceableStatus: eventingduckv1alpha1.PlaceableStatus{Placeable: eventingduckv1alpha1.Placeable{
+				MaxAllowedVReplicas: pointer.Int32(1),
+				Placements:          []eventingduckv1alpha1.Placement{},
+			}},
+		},
+	}
+	cg.GetConditionSet().Manage(cg.GetStatus()).InitializeConditions()
+	cg.MarkScheduleSucceeded()
+
+	placement := &eventingduckv1alpha1.Placement{PodName: pod1.GetName(), VReplicas: 1}
+
+	ctx, _ = kubeclient.With(ctx, pod)
+	ctx, _ = kafkainternalsclient.With(ctx, cg)
+
+	e := newEvictor(ctx)
+	err := e.evict(pod, cg, placement)
+
+	require.Nil(t, err)
+}
+
 func TestEvictorNoEviction(t *testing.T) {
 	ctx, _ := reconcilertesting.SetupFakeContext(t)
 


### PR DESCRIPTION
Backport of upstream #2923 

```
E0125 19:04:18.704663       1 runtime.go:79] Observed a panic: "makeslice: cap out of range" (runtime error: makeslice: cap out of range)
goroutine 427 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1d6fba0?, 0x2408810})
	/remote-source/knative-kafka-broker/app/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x7fcd35b823a0?})
	/remote-source/knative-kafka-broker/app/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x75
panic({0x1d6fba0, 0x2408810})
	/usr/lib/golang/src/runtime/panic.go:838 +0x207
knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/consumergroup.removePlacement(...)
```

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>