### PR TITLE
[WIP] Reduce global resyncs for Source v2

### DIFF
--- a/control-plane/pkg/counter/counter.go
+++ b/control-plane/pkg/counter/counter.go
@@ -32,7 +32,7 @@ type Counter struct {
 }
 
 func NewExpiringCounter(ctx context.Context) *Counter {
-	cache := prober.NewLocalExpiringCache(ctx, 10*time.Minute)
+	cache := prober.NewLocalExpiringCache(ctx, 30*time.Minute)
 	return &Counter{
 		cache: cache,
 	}

--- a/control-plane/pkg/reconciler/consumer/controller.go
+++ b/control-plane/pkg/reconciler/consumer/controller.go
@@ -33,7 +33,6 @@ import (
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/informers/eventing/v1alpha1/consumergroup"
 	creconciler "knative.dev/eventing-kafka-broker/control-plane/pkg/client/internals/kafka/injection/reconciler/eventing/v1alpha1/consumer"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
-	cgreconciler "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/consumergroup"
 )
 
 type ControllerConfig struct {
@@ -72,12 +71,6 @@ func NewController(ctx context.Context, watcher configmap.Watcher) *controller.I
 
 	r.Tracker = impl.Tracker
 	secretinformer.Get(ctx).Informer().AddEventHandler(controller.HandleAll(r.Tracker.OnChanged))
-
-	globalResync := func(interface{}) {
-		impl.GlobalResync(consumerInformer.Informer())
-	}
-
-	cgreconciler.ResyncOnStatefulSetChange(ctx, globalResync)
 
 	return impl
 }

--- a/control-plane/pkg/reconciler/consumergroup/auth.go
+++ b/control-plane/pkg/reconciler/consumergroup/auth.go
@@ -27,7 +27,7 @@ import (
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/security"
 )
 
-func (r Reconciler) newAuthConfigOption(ctx context.Context, cg *kafkainternals.ConsumerGroup) (kafka.ConfigOption, error) {
+func (r *Reconciler) newAuthConfigOption(ctx context.Context, cg *kafkainternals.ConsumerGroup) (kafka.ConfigOption, error) {
 	var secret *corev1.Secret
 
 	if hasAuthSpecAuthConfig(cg.Spec.Template.Spec.Auth) {

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
@@ -167,8 +167,14 @@ func TestReconcileKind(t *testing.T) {
 			Name: "Consumers in multiple pods, with pods pending and unknown phase",
 			Objects: []runtime.Object{
 				NewService(),
-				NewDispatcherPod("p1", PodLabel(kafkainternals.SourceStatefulSetName), PodPending()),
-				NewDispatcherPod("p2", PodLabel(kafkainternals.SourceStatefulSetName)),
+				NewDispatcherPod("p1",
+					PodLabel("app", kafkainternals.SourceStatefulSetName),
+					PodLabel("app-version", "v2"),
+					PodPending()),
+				NewDispatcherPod("p2",
+					PodLabel("app", kafkainternals.SourceStatefulSetName),
+					PodLabel("app-version", "v2"),
+				),
 				NewConsumerGroup(
 					ConsumerGroupConsumerSpec(NewConsumerSpec(
 						ConsumerTopics("t1", "t2"),
@@ -1622,7 +1628,7 @@ func TestReconcileKind(t *testing.T) {
 		_, exampleConfig := cm.ConfigMapsFromTestFile(t, configapis.FlagsConfigName)
 		store.OnConfigChanged(exampleConfig)
 
-		r := Reconciler{
+		r := &Reconciler{
 			SchedulerFunc: func(s string) Scheduler {
 				ss := row.OtherTestData[testSchedulerKey].(scheduler.Scheduler)
 				return Scheduler{
@@ -1764,7 +1770,7 @@ func TestReconcileKindNoAutoscaler(t *testing.T) {
 
 		ctx, _ = kedaclient.With(ctx)
 
-		r := Reconciler{
+		r := &Reconciler{
 			SchedulerFunc: func(s string) Scheduler {
 				ss := row.OtherTestData[testSchedulerKey].(scheduler.Scheduler)
 				return Scheduler{

--- a/control-plane/pkg/reconciler/testing/objects_common.go
+++ b/control-plane/pkg/reconciler/testing/objects_common.go
@@ -576,12 +576,12 @@ func NewDispatcherPod(name string, options ...PodOption) *corev1.Pod {
 	return p
 }
 
-func PodLabel(value string) PodOption {
+func PodLabel(key, value string) PodOption {
 	return func(pod *corev1.Pod) {
 		if pod.Labels == nil {
 			pod.Labels = make(map[string]string, 2)
 		}
-		pod.Labels["app"] = value
+		pod.Labels[key] = value
 	}
 }
 


### PR DESCRIPTION
In the soak tests, I observed that the queue depth was constantly very high for the ConsumerGroup reconciler, which leads to a very slow reconciliation process.

One reason for this might be that the scheduler is single thread but the main reason is that we were doing a lot of global resyncs (in both Consumer and ConsumerGroup reconciler) triggered by any StatefulSet updates which produces many API server remote call and have increased the API server remote calls latency due to client-side throttling.

To avoid global resyncs we're now requeue-ing individual objects only when some (expected) replicas are not schedule-able due to missing pods, and we drop the need to global resync when the statefulset changes in response to the autoscaler scaling up the statefulset to make room for new replicas.

In the eviction case, when the statefulset is scaled down, individual objects are patched, which triggers ConsumerGroup reconciliation, so we need to queue individual objects only when virtual replicas count is not equal to the expected number of replicas.

Context: https://redhat-internal.slack.com/archives/CEXRYS5QC/p1674729777718059

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>