### PR TITLE
Remove eventlibrary from rekt image replaces

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -39,7 +39,6 @@ resolve_resources vendor/knative.dev/eventing/test/test_images/event-sender vend
 resolve_resources vendor/knative.dev/eventing/test/rekt/resources/containersource vendor/knative.dev/eventing/test/rekt/resources/containersource/containersource.yaml "${image_prefix}" "${tag}" true
 resolve_resources vendor/knative.dev/reconciler-test/pkg/eventshub vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml "${image_prefix}" "${tag}" true "eventshub"
 resolve_resources vendor/knative.dev/eventing/test/rekt/resources/flaker vendor/knative.dev/eventing/test/rekt/resources/flaker/flaker.yaml "${image_prefix}" "${tag}" true
-resolve_resources vendor/knative.dev/eventing/test/rekt/resources/eventlibrary vendor/knative.dev/eventing/test/rekt/resources/eventlibrary/eventlibrary.yaml "${image_prefix}" "${tag}" true
 
 eventing_kafka_controller="${artifacts_dir}eventing-kafka-controller.yaml"
 eventing_kafka_post_install="${artifacts_dir}eventing-kafka-post-install.yaml"


### PR DESCRIPTION
Currently we have the following CI issues [knative-nightly-ci-eventing-kafka-broker/185/console](https://master-jenkins-csb-serverless-qe.apps.ocp-c1.prod.psi.redhat.com/job/ci/job/knative-nightly-ci-eventing-kafka-broker/185/console): 
```
01:42:50  vendor/knative.dev/eventing/test/rekt/resources/eventlibrary vendor/knative.dev/eventing/test/rekt/resources/eventlibrary/eventlibrary.yaml registry.ci.openshift.org/openshift/knative-eventing-kafka-broker knative-nightly true
01:42:50  Writing resolved yaml to vendor/knative.dev/eventing/test/rekt/resources/eventlibrary/eventlibrary.yaml knative-nightly
01:42:50  Resolving vendor/knative.dev/eventing/test/rekt/resources/eventlibrary/*.yaml
01:42:50  sed: can't read vendor/knative.dev/eventing/test/rekt/resources/eventlibrary/*.yaml: No such file or directory
01:42:50  make: *** [Makefile:75: generate-release] Error 2
```

This comes, as `vendor/knative.dev/eventing/test/rekt/resources/eventlibrary` was removed in https://github.com/knative-sandbox/eventing-kafka-broker/pull/2920