### PR TITLE
[SRVKE-1400] Autoscaler improvements

### DIFF
--- a/control-plane/pkg/reconciler/consumergroup/controller.go
+++ b/control-plane/pkg/reconciler/consumergroup/controller.go
@@ -146,6 +146,20 @@ func NewController(ctx context.Context, watcher configmap.Watcher) *controller.I
 
 	ResyncOnStatefulSetChange(ctx, globalResync)
 
+	go func() {
+		for {
+			select {
+			case <-time.After(c.RefreshPeriod):
+				logger.Debugw("Global resync after refresh period",
+					zap.Duration("refreshPeriod", c.RefreshPeriod),
+				)
+				globalResync(nil)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
 	//Todo: ScaledObject informer when KEDA is installed
 
 	return impl

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -42,6 +42,77 @@ function timeout() {
   return 0
 }
 
+function scale_up_workers {
+  local current_total az_total replicas idx ignored_zone
+  local SCALE_UP="$1"
+  if [[ "${SCALE_UP}" -lt "0" ]]; then
+    logger.info 'Skipping scaling up, because SCALE_UP is negative.'
+    return 0
+  fi
+
+  if ! cluster_scalable; then
+    logger.info 'Skipping scaling up, the cluster is not scalable.'
+    return 0
+  fi
+
+  logger.info "Scaling cluster to ${SCALE_UP}"
+
+  logger.debug 'Get the machineset with most replicas'
+  current_total="$(oc get machineconfigpool worker -o jsonpath='{.status.readyMachineCount}')"
+
+  # WORKAROUND: OpenShift in CI cannot scale machine set in us-east-1e zone and throws:
+  # Your requested instance type (m5.xlarge) is not supported in your requested Availability Zone
+  # (us-east-1e). Please retry your request by not specifying an Availability Zone
+  # or choosing us-east-1a, us-east-1b, us-east-1c, us-east-1d, us-east-1f."
+  ignored_zone="us-east-1e"
+  az_total="$(oc get machineset -n openshift-machine-api -oname | grep -cv "$ignored_zone")"
+
+  logger.debug "ready machine count: ${current_total}, number of available zones: ${az_total}"
+
+  if [[ "${SCALE_UP}" == "${current_total}" ]]; then
+    logger.success "Cluster is already scaled up to ${SCALE_UP} replicas"
+    return 0
+  fi
+
+  idx=0
+  for mset in $(oc get machineset -n openshift-machine-api -o name | grep -v "$ignored_zone"); do
+    replicas=$(( SCALE_UP / az_total ))
+    if [ ${idx} -lt $(( SCALE_UP % az_total )) ];then
+      (( replicas++ )) || true
+    fi
+    (( idx++ )) || true
+    logger.debug "Bump ${mset} to ${replicas}"
+    oc scale "${mset}" -n openshift-machine-api --replicas="${replicas}"
+  done
+  wait_until_machineset_scales_up "${SCALE_UP}"
+}
+
+# Waits until worker nodes scale up to the desired number of replicas
+# Parameters: $1 - desired number of replicas
+function wait_until_machineset_scales_up {
+  logger.info "Waiting until worker nodes scale up to $1 replicas"
+  local available
+  for _ in {1..150}; do  # timeout after 15 minutes
+    available=$(oc get machineconfigpool worker -o jsonpath='{.status.readyMachineCount}')
+    if [[ ${available} -eq $1 ]]; then
+      echo ''
+      logger.success "successfully scaled up to $1 replicas"
+      return 0
+    fi
+    echo -n "."
+    sleep 6
+  done
+  echo -e "\n\n"
+  logger.error "Timeout waiting for scale up to $1 replicas"
+  return 1
+}
+
+function cluster_scalable {
+  if [[ $(oc get infrastructure cluster -ojsonpath='{.status.platform}') = VSphere ]]; then
+    return 1
+  fi
+}
+
 function install_serverless() {
   header "Installing Serverless Operator"
 

--- a/openshift/e2e-rekt-tests.sh
+++ b/openshift/e2e-rekt-tests.sh
@@ -7,6 +7,8 @@ set -Eeuox pipefail
 
 failed=0
 
+(( !failed )) && scale_up_workers "4" || failed=1
+
 (( !failed )) && install_serverless || failed=1
 
 (( !failed )) && run_e2e_new_tests || failed=1

--- a/openshift/patches/fix_scheduler_and_autoscaler_scale_down_delay.patch
+++ b/openshift/patches/fix_scheduler_and_autoscaler_scale_down_delay.patch
@@ -1,0 +1,339 @@
+diff --git a/vendor/knative.dev/eventing/pkg/scheduler/state/state.go b/vendor/knative.dev/eventing/pkg/scheduler/state/state.go
+index e84f311fc..539bb94c8 100644
+--- a/vendor/knative.dev/eventing/pkg/scheduler/state/state.go
++++ b/vendor/knative.dev/eventing/pkg/scheduler/state/state.go
+@@ -18,6 +18,7 @@ package state
+ 
+ import (
+ 	"context"
++	"encoding/json"
+ 	"errors"
+ 	"fmt"
+ 	"strconv"
+@@ -97,6 +98,49 @@ type State struct {
+ 	ZoneSpread map[types.NamespacedName]map[string]int32
+ }
+ 
++func (s *State) MarshalJSON() ([]byte, error) {
++
++	type S struct {
++		FreeCap         []int32                     `json:"freeCap"`
++		SchedulablePods []int32                     `json:"schedulablePods"`
++		LastOrdinal     int32                       `json:"lastOrdinal"`
++		Capacity        int32                       `json:"capacity"`
++		Replicas        int32                       `json:"replicas"`
++		NumZones        int32                       `json:"numZones"`
++		NumNodes        int32                       `json:"numNodes"`
++		NodeToZoneMap   map[string]string           `json:"nodeToZoneMap"`
++		StatefulSetName string                      `json:"statefulSetName"`
++		PodSpread       map[string]map[string]int32 `json:"podSpread"`
++		NodeSpread      map[string]map[string]int32 `json:"nodeSpread"`
++		ZoneSpread      map[string]map[string]int32 `json:"zoneSpread"`
++	}
++
++	toJSONable := func(ps map[types.NamespacedName]map[string]int32) map[string]map[string]int32 {
++		r := make(map[string]map[string]int32, len(ps))
++		for k, v := range ps {
++			r[k.String()] = v
++		}
++		return r
++	}
++
++	sj := S{
++		FreeCap:         s.FreeCap,
++		SchedulablePods: s.SchedulablePods,
++		LastOrdinal:     s.LastOrdinal,
++		Capacity:        s.Capacity,
++		Replicas:        s.Replicas,
++		NumZones:        s.NumZones,
++		NumNodes:        s.NumNodes,
++		NodeToZoneMap:   s.NodeToZoneMap,
++		StatefulSetName: s.StatefulSetName,
++		PodSpread:       toJSONable(s.PodSpread),
++		NodeSpread:      toJSONable(s.NodeSpread),
++		ZoneSpread:      toJSONable(s.ZoneSpread),
++	}
++
++	return json.Marshal(sj)
++}
++
+ // Free safely returns the free capacity at the given ordinal
+ func (s *State) Free(ordinal int32) int32 {
+ 	if int32(len(s.FreeCap)) <= ordinal {
+@@ -308,10 +352,13 @@ func (s *stateBuilder) State(reserved map[types.NamespacedName]map[string]int32)
+ 		}
+ 	}
+ 
+-	s.logger.Infow("cluster state info", zap.String("NumPods", fmt.Sprint(scale.Spec.Replicas)), zap.String("NumZones", fmt.Sprint(len(zoneMap))), zap.String("NumNodes", fmt.Sprint(len(nodeToZoneMap))), zap.String("Schedulable", fmt.Sprint(schedulablePods)))
+-	return &State{FreeCap: free, SchedulablePods: schedulablePods.List(), LastOrdinal: last, Capacity: s.capacity, Replicas: scale.Spec.Replicas, NumZones: int32(len(zoneMap)), NumNodes: int32(len(nodeToZoneMap)),
++	state := &State{FreeCap: free, SchedulablePods: schedulablePods.List(), LastOrdinal: last, Capacity: s.capacity, Replicas: scale.Spec.Replicas, NumZones: int32(len(zoneMap)), NumNodes: int32(len(nodeToZoneMap)),
+ 		SchedulerPolicy: s.schedulerPolicy, SchedPolicy: s.schedPolicy, DeschedPolicy: s.deschedPolicy, NodeToZoneMap: nodeToZoneMap, StatefulSetName: s.statefulSetName, PodLister: s.podLister,
+-		PodSpread: podSpread, NodeSpread: nodeSpread, ZoneSpread: zoneSpread}, nil
++		PodSpread: podSpread, NodeSpread: nodeSpread, ZoneSpread: zoneSpread}
++
++	s.logger.Debugw("cluster state info", zap.Any("state", state))
++
++	return state, nil
+ }
+ 
+ func (s *stateBuilder) updateFreeCapacity(free []int32, last int32, podName string, vreplicas int32) ([]int32, int32) {
+@@ -402,3 +449,12 @@ func contains(taints []v1.Taint, taint *v1.Taint) bool {
+ 	}
+ 	return false
+ }
++
++func (s *State) IsSchedulablePod(ordinal int32) bool {
++	for _, x := range s.SchedulablePods {
++		if x == ordinal {
++			return true
++		}
++	}
++	return false
++}
+diff --git a/vendor/knative.dev/eventing/pkg/scheduler/statefulset/autoscaler.go b/vendor/knative.dev/eventing/pkg/scheduler/statefulset/autoscaler.go
+index d0a54f208..c740b00a0 100644
+--- a/vendor/knative.dev/eventing/pkg/scheduler/statefulset/autoscaler.go
++++ b/vendor/knative.dev/eventing/pkg/scheduler/statefulset/autoscaler.go
+@@ -42,10 +42,11 @@ type Autoscaler interface {
+ 
+ 	// Autoscale is used to immediately trigger the autoscaler with the hint
+ 	// that pending number of vreplicas couldn't be scheduled.
+-	Autoscale(ctx context.Context, attemptScaleDown bool, pending int32)
++	Autoscale(ctx context.Context, trigger AutoscaleTrigger)
+ }
+ 
+ type AutoscaleTrigger struct {
++	Reseved         Reseved
+ 	AttempScaleDown bool
+ 	Pending         int32
+ }
+@@ -63,8 +64,9 @@ type autoscaler struct {
+ 	capacity int32
+ 
+ 	// refreshPeriod is how often the autoscaler tries to scale down the statefulset
+-	refreshPeriod time.Duration
+-	lock          sync.Locker
++	refreshPeriod      time.Duration
++	lastCompactAttempt time.Time
++	lock               sync.Locker
+ }
+ 
+ func NewAutoscaler(ctx context.Context,
+@@ -86,6 +88,11 @@ func NewAutoscaler(ctx context.Context,
+ 		capacity:          capacity,
+ 		refreshPeriod:     refreshPeriod,
+ 		lock:              new(sync.Mutex),
++		// Anything that is less than now() - refreshPeriod, so that we will try to compact
++		// as soon as we start.
++		lastCompactAttempt: time.Now().
++			Add(-refreshPeriod).
++			Add(-time.Minute),
+ 	}
+ }
+ 
+@@ -96,7 +103,7 @@ func (a *autoscaler) Start(ctx context.Context) {
+ 		case <-ctx.Done():
+ 			return
+ 		case t := <-a.trigger:
+-			a.syncAutoscale(ctx, t.AttempScaleDown, t.Pending)
++			a.syncAutoscale(ctx, t)
+ 		}
+ 	}
+ }
+@@ -112,25 +119,25 @@ func (a *autoscaler) maybeTriggerAutoscaleOnStart() {
+ 	}
+ }
+ 
+-func (a *autoscaler) Autoscale(ctx context.Context, attemptScaleDown bool, pending int32) {
++func (a *autoscaler) Autoscale(ctx context.Context, trigger AutoscaleTrigger) {
+ 	select {
+-	case a.trigger <- AutoscaleTrigger{AttempScaleDown: attemptScaleDown, Pending: pending}:
++	case a.trigger <- trigger:
+ 	default:
+ 	}
+ }
+ 
+-func (a *autoscaler) syncAutoscale(ctx context.Context, attemptScaleDown bool, pending int32) {
++func (a *autoscaler) syncAutoscale(ctx context.Context, trigger AutoscaleTrigger) {
+ 	a.lock.Lock()
+ 	defer a.lock.Unlock()
+ 
+ 	wait.Poll(500*time.Millisecond, 5*time.Second, func() (bool, error) {
+-		err := a.doautoscale(ctx, attemptScaleDown, pending)
++		err := a.doautoscale(ctx, trigger)
+ 		return err == nil, nil
+ 	})
+ }
+ 
+-func (a *autoscaler) doautoscale(ctx context.Context, attemptScaleDown bool, pending int32) error {
+-	state, err := a.stateAccessor.State(nil)
++func (a *autoscaler) doautoscale(ctx context.Context, trigger AutoscaleTrigger) error {
++	state, err := a.stateAccessor.State(trigger.Reseved)
+ 	if err != nil {
+ 		a.logger.Info("error while refreshing scheduler state (will retry)", zap.Error(err))
+ 		return err
+@@ -144,9 +151,9 @@ func (a *autoscaler) doautoscale(ctx context.Context, attemptScaleDown bool, pen
+ 	}
+ 
+ 	a.logger.Infow("checking adapter capacity",
+-		zap.Int32("pending", pending),
++		zap.Int32("pending", trigger.Pending),
+ 		zap.Int32("replicas", scale.Spec.Replicas),
+-		zap.Int32("last ordinal", state.LastOrdinal))
++		zap.Any("state", state))
+ 
+ 	var scaleUpFactor, newreplicas, minNumPods int32
+ 	scaleUpFactor = 1                                                                                         // Non-HA scaling
+@@ -160,13 +167,13 @@ func (a *autoscaler) doautoscale(ctx context.Context, attemptScaleDown bool, pen
+ 	newreplicas = state.LastOrdinal + 1 // Ideal number
+ 
+ 	// Take into account pending replicas and pods that are already filled (for even pod spread)
+-	if pending > 0 {
++	if trigger.Pending > 0 {
+ 		// Make sure to allocate enough pods for holding all pending replicas.
+ 		if state.SchedPolicy != nil && contains(state.SchedPolicy.Predicates, nil, st.EvenPodSpread) && len(state.FreeCap) > 0 { //HA scaling across pods
+ 			leastNonZeroCapacity := a.minNonZeroInt(state.FreeCap)
+-			minNumPods = int32(math.Ceil(float64(pending) / float64(leastNonZeroCapacity)))
++			minNumPods = int32(math.Ceil(float64(trigger.Pending) / float64(leastNonZeroCapacity)))
+ 		} else {
+-			minNumPods = int32(math.Ceil(float64(pending) / float64(a.capacity)))
++			minNumPods = int32(math.Ceil(float64(trigger.Pending) / float64(a.capacity)))
+ 		}
+ 		newreplicas += int32(math.Ceil(float64(minNumPods)/float64(scaleUpFactor)) * float64(scaleUpFactor))
+ 	}
+@@ -177,11 +184,15 @@ func (a *autoscaler) doautoscale(ctx context.Context, attemptScaleDown bool, pen
+ 	}
+ 
+ 	// Only scale down if permitted
+-	if !attemptScaleDown && newreplicas < scale.Spec.Replicas {
++	if !trigger.AttempScaleDown && newreplicas < scale.Spec.Replicas {
+ 		newreplicas = scale.Spec.Replicas
+ 	}
+ 
+-	a.logger.Debugf("expected replicas %d, got %d", newreplicas, scale.Spec.Replicas)
++	a.logger.Debugw("Final scaling decision",
++		zap.Int32("expected", newreplicas),
++		zap.Int32("got", scale.Spec.Replicas),
++		zap.Bool("attempScaleDown", trigger.AttempScaleDown),
++	)
+ 
+ 	if newreplicas != scale.Spec.Replicas {
+ 		scale.Spec.Replicas = newreplicas
+@@ -192,7 +203,7 @@ func (a *autoscaler) doautoscale(ctx context.Context, attemptScaleDown bool, pen
+ 			a.logger.Errorw("updating scale subresource failed", zap.Error(err))
+ 			return err
+ 		}
+-	} else if attemptScaleDown {
++	} else if trigger.AttempScaleDown {
+ 		// since the number of replicas hasn't changed and time has approached to scale down,
+ 		// take the opportunity to compact the vreplicas
+ 		a.mayCompact(state, scaleUpFactor)
+@@ -202,10 +213,21 @@ func (a *autoscaler) doautoscale(ctx context.Context, attemptScaleDown bool, pen
+ 
+ func (a *autoscaler) mayCompact(s *st.State, scaleUpFactor int32) {
+ 
++	// This avoids a too aggressive scale down by adding a "grace period" based on the refresh
++	// period
++	nextAttempt := a.lastCompactAttempt.Add(a.refreshPeriod)
++	if time.Now().Before(nextAttempt) {
++		a.logger.Debugw("Compact was retried before refresh period",
++			zap.Time("lastCompactAttempt", a.lastCompactAttempt),
++			zap.Time("nextAttempt", nextAttempt),
++			zap.String("refreshPeriod", a.refreshPeriod.String()),
++		)
++		return
++	}
++
+ 	a.logger.Debugw("Trying to compact and scale down",
+ 		zap.Int32("scaleUpFactor", scaleUpFactor),
+-		zap.Any("schedulablePods", s.SchedulablePods),
+-		zap.Int32("lastOrdinal", s.LastOrdinal),
++		zap.Any("state", s),
+ 	)
+ 
+ 	// when there is only one pod there is nothing to move or number of pods is just enough!
+@@ -220,6 +242,9 @@ func (a *autoscaler) mayCompact(s *st.State, scaleUpFactor int32) {
+ 		usedInLastPod := s.Capacity - s.Free(s.LastOrdinal)
+ 
+ 		if freeCapacity >= usedInLastPod {
++
++			a.lastCompactAttempt = time.Now()
++
+ 			err := a.compact(s, scaleUpFactor)
+ 			if err != nil {
+ 				a.logger.Errorw("vreplicas compaction failed", zap.Error(err))
+diff --git a/vendor/knative.dev/eventing/pkg/scheduler/statefulset/scheduler.go b/vendor/knative.dev/eventing/pkg/scheduler/statefulset/scheduler.go
+index 1d22452eb..bb40bd372 100644
+--- a/vendor/knative.dev/eventing/pkg/scheduler/statefulset/scheduler.go
++++ b/vendor/knative.dev/eventing/pkg/scheduler/statefulset/scheduler.go
+@@ -106,6 +106,8 @@ type StatefulSetScheduler struct {
+ 	reserved map[types.NamespacedName]map[string]int32
+ }
+ 
++type Reseved map[types.NamespacedName]map[string]int32
++
+ func NewStatefulSetScheduler(ctx context.Context,
+ 	namespace, name string,
+ 	lister scheduler.VPodLister,
+@@ -167,7 +169,11 @@ func (s *StatefulSetScheduler) Schedule(vpod scheduler.VPod) ([]duckv1alpha1.Pla
+ 
+ func (s *StatefulSetScheduler) scheduleVPod(vpod scheduler.VPod) ([]duckv1alpha1.Placement, error) {
+ 	// Attempt to scale down (async)
+-	defer s.autoscaler.Autoscale(s.ctx, true, s.pendingVReplicas())
++	defer s.autoscaler.Autoscale(s.ctx, AutoscaleTrigger{
++		Reseved:         s.copyReserved(),
++		AttempScaleDown: true,
++		Pending:         s.pendingVReplicas(),
++	})
+ 
+ 	logger := s.logger.With("key", vpod.GetKey())
+ 	logger.Info("scheduling")
+@@ -180,10 +186,17 @@ func (s *StatefulSetScheduler) scheduleVPod(vpod scheduler.VPod) ([]duckv1alpha1
+ 		return nil, err
+ 	}
+ 
+-	placements := vpod.GetPlacements()
+-	existingPlacements := placements
++	existingPlacements := vpod.GetPlacements()
+ 	var left int32
+ 
++	placements := make([]duckv1alpha1.Placement, 0, len(existingPlacements))
++	// Remove unschedulable pods from placements
++	for _, p := range existingPlacements {
++		if state.IsSchedulablePod(st.OrdinalFromPodName(p.PodName)) {
++			placements = append(placements, *p.DeepCopy())
++		}
++	}
++
+ 	// The scheduler when policy type is
+ 	// Policy: MAXFILLUP (SchedulerPolicyType == MAXFILLUP)
+ 	// - allocates as many vreplicas as possible to the same pod(s)
+@@ -245,7 +258,11 @@ func (s *StatefulSetScheduler) scheduleVPod(vpod scheduler.VPod) ([]duckv1alpha1
+ 
+ 		// Trigger the autoscaler (async)
+ 		if s.autoscaler != nil {
+-			s.autoscaler.Autoscale(s.ctx, false, s.pendingVReplicas())
++			s.autoscaler.Autoscale(s.ctx, AutoscaleTrigger{
++				Reseved:         s.copyReserved(),
++				AttempScaleDown: false,
++				Pending:         s.pendingVReplicas(),
++			})
+ 		}
+ 
+ 		if state.SchedPolicy != nil {
+@@ -733,3 +750,15 @@ func (s *StatefulSetScheduler) notEnoughPodReplicas(left int32) error {
+ 		controller.NewRequeueAfter(5*time.Second),
+ 	)
+ }
++
++func (s *StatefulSetScheduler) copyReserved() Reseved {
++	reserved := make(Reseved, len(s.reserved))
++	for k, v := range s.reserved {
++		vv := make(map[string]int32, len(v))
++		for k1, v1 := range v {
++			vv[k1] = v1
++		}
++		reserved[k] = vv
++	}
++	return reserved
++}

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -10,6 +10,7 @@ git apply openshift/patches/override-min-version.patch
 git apply openshift/patches/use_kafkacat_from_ocp.patch
 git apply openshift/patches/security-context-for-test-pods.patch
 git apply openshift/patches/fix_scheduler_and_autoscaler.patch
+git apply openshift/patches/fix_scheduler_and_autoscaler_scale_down_delay.patch
 
 # Eventing core will bring the config tracing ConfigMap, so remove it from heret
 rm -f control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml

--- a/test/e2e_new/features/kafka_source.go
+++ b/test/e2e_new/features/kafka_source.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +65,7 @@ func SetupKafkaSources(prefix string, n int) *feature.Feature {
 			kafkasource.WithSink(&duckv1.KReference{Kind: "Service", Name: sink, APIVersion: "v1"}, ""),
 		))
 
-		f.Assert(fmt.Sprintf("kafkasource %s is ready", name), kafkasource.IsReady(name))
+		f.Assert(fmt.Sprintf("kafkasource %s is ready", name), kafkasource.IsReady(name, 3*time.Second, 5*time.Minute))
 	}
 
 	return f

--- a/test/e2e_new/kafka_source_test.go
+++ b/test/e2e_new/kafka_source_test.go
@@ -54,9 +54,8 @@ func TestKafkaSourceDeletedFromContractConfigMaps(t *testing.T) {
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
-		environment.Managed(t),
+		environment.WithTestLogger(t),
 	)
-	t.Cleanup(env.Finish)
 
 	env.Test(ctx, t, features.SetupKafkaSources("permanent-kafka-source-", 21))
 	env.Test(ctx, t, features.SetupAndCleanupKafkaSources("x-kafka-source-", 42))


### PR DESCRIPTION
Introduce a scale down delay so that the scaling down is more
consistent and converges to a specific number of replicas
(similar to how it was before)

Improve autoscaler state logging

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>