### PR TITLE
using UBI and nonroot user

### DIFF
--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -4,7 +4,8 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+USER 65532
 
 COPY --from=builder /go/bin/${bin} /usr/bin/${bin}
 ENTRYPOINT ["/usr/bin/${bin}"]


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

stashing the UBI change on `main` for future (1.9+) branch creation