### PR TITLE
Update patch to remove seccomp profiles

### DIFF
--- a/openshift/patches/remove_seccomp_profile.patch
+++ b/openshift/patches/remove_seccomp_profile.patch
@@ -80,13 +80,13 @@ index 4ba55f5a9..8dafdc1b8 100644
          - name: kafka-broker-brokers-triggers
            configMap:
 diff --git a/data-plane/config/brokerv2/500-dispatcher.yaml b/data-plane/config/brokerv2/500-dispatcher.yaml
-index 5f850fe8c..ed40dc782 100644
+index 27d9ecc44..12b78c93b 100644
 --- a/data-plane/config/brokerv2/500-dispatcher.yaml
 +++ b/data-plane/config/brokerv2/500-dispatcher.yaml
-@@ -153,8 +153,6 @@ spec:
+@@ -158,8 +158,6 @@ spec:
              capabilities:
                drop:
-               - ALL
+                 - ALL
 -            seccompProfile:
 -              type: RuntimeDefault
        volumes:


### PR DESCRIPTION
Current CI issue:

```
01:34:12  error: patch failed: data-plane/config/brokerv2/500-dispatcher.yaml:153
01:34:12  error: data-plane/config/brokerv2/500-dispatcher.yaml: patch does not apply
```

Changes on `brokerv2/500-dispatcher.yaml` were introduced in https://github.com/knative-sandbox/eventing-kafka-broker/pull/2977