### PR TITLE
Remove event flaker test image

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -14,7 +14,6 @@ default_test_image_template=$(
 {{- if eq . "recordevents"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_RECORDEVENTS{{end -}}
 {{- if eq . "print"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_PRINT{{end -}}
 {{- if eq . "performance"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_PERFORMANCE{{end -}}
-{{- if eq . "event-library"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_EVENT_LIBRARY{{end -}}
 {{- if eq . "committed-offset"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_COMMITTED_OFFSET{{end -}}
 {{- if eq . "consumer-group-lag-provider-test"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_CONSUMER_GROUP_LAG_PROVIDER_TEST{{end -}}
 {{- if eq . "kafka-consumer"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_KAFKA_CONSUMER{{end -}}

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -14,7 +14,6 @@ default_test_image_template=$(
 {{- if eq . "recordevents"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_RECORDEVENTS{{end -}}
 {{- if eq . "print"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_PRINT{{end -}}
 {{- if eq . "performance"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_PERFORMANCE{{end -}}
-{{- if eq . "event-flaker"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_EVENT_FLAKER{{end -}}
 {{- if eq . "event-library"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_EVENT_LIBRARY{{end -}}
 {{- if eq . "committed-offset"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_COMMITTED_OFFSET{{end -}}
 {{- if eq . "consumer-group-lag-provider-test"}}$KNATIVE_EVENTING_KAFKA_BROKER_TEST_CONSUMER_GROUP_LAG_PROVIDER_TEST{{end -}}

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -38,7 +38,6 @@ resolve_resources vendor/knative.dev/eventing/test/test_images/heartbeats vendor
 resolve_resources vendor/knative.dev/eventing/test/test_images/event-sender vendor/knative.dev/eventing/test/test_images/event-sender/pod.yaml "${image_prefix}" "${tag}" true
 resolve_resources vendor/knative.dev/eventing/test/rekt/resources/containersource vendor/knative.dev/eventing/test/rekt/resources/containersource/containersource.yaml "${image_prefix}" "${tag}" true
 resolve_resources vendor/knative.dev/reconciler-test/pkg/eventshub vendor/knative.dev/reconciler-test/pkg/eventshub/103-pod.yaml "${image_prefix}" "${tag}" true "eventshub"
-resolve_resources vendor/knative.dev/eventing/test/rekt/resources/flaker vendor/knative.dev/eventing/test/rekt/resources/flaker/flaker.yaml "${image_prefix}" "${tag}" true
 
 eventing_kafka_controller="${artifacts_dir}eventing-kafka-controller.yaml"
 eventing_kafka_post_install="${artifacts_dir}eventing-kafka-post-install.yaml"


### PR DESCRIPTION
* Event-flaker image was removed in https://github.com/knative/eventing/pull/6750 and in CI in https://github.com/openshift/release/pull/36826.

* Additionally this PR cleans up a leftover from the event-library removal from https://github.com/openshift-knative/eventing-kafka-broker/pull/586