### PR TITLE
TracingHeadersUsingUnorderedDeliveryWithMultipleTriggers waits for bo…

### DIFF
--- a/test/e2e_new/tracing_test.go
+++ b/test/e2e_new/tracing_test.go
@@ -294,7 +294,8 @@ func TracingHeadersUsingUnorderedDeliveryWithMultipleTriggers() *feature.Feature
 		brokerName,
 		trigger.WithSubscriber(svc.AsKReference(sinkName), ""),
 	))
-	f.Setup("trigger is ready", trigger.IsReady(triggerAName))
+	f.Setup("trigger a is ready", trigger.IsReady(triggerAName))
+	f.Setup("trigger b is ready", trigger.IsReady(triggerBName))
 
 	f.Requirement("install source", eventshub.Install(
 		sourceName,


### PR DESCRIPTION
…th triggers to be ready

Backport of upstream https://github.com/knative-sandbox/eventing-kafka-broker/pull/3000

This should be cherry-picked on release-v1.7