### PR TITLE
Remove e2e tests on `test/e2e_broker` directory

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -82,10 +82,6 @@ function run_e2e_tests() {
   go_test_e2e -timeout=100m -short ./test/e2e/ \
     -imagetemplate "${TEST_IMAGE_TEMPLATE}" || return $?
 
-  echo "Running e2e tests, directory ./test/e2e_broker/"
-  go_test_e2e -timeout=100m -short ./test/e2e_broker/ \
-    -imagetemplate "${TEST_IMAGE_TEMPLATE}" || return $?
-
   echo "Running e2e tests, directory ./test/e2e_sink/"
   go_test_e2e -timeout=100m -short ./test/e2e_sink/ \
     -imagetemplate "${TEST_IMAGE_TEMPLATE}" || return $?


### PR DESCRIPTION
Remove the e2e tests running in the test/e2e_broker directory as the directory was removed in
https://github.com/knative-sandbox/eventing-kafka-broker/pull/3004

See issues e.g. in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_eventing-kafka-broker/631/pull-ci-openshift-knative-eventing-kafka-broker-release-next-412-test-e2e-aws-ocp-412/1635080131514994688