### PR TITLE
[release-v1.8] Fix broken initial offset on reset on a non64 bit boundary (#3023)

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OffsetManager.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/OffsetManager.java
@@ -293,8 +293,9 @@ public final class OffsetManager implements RecordDispatcherListener {
 
       final var prevCommittedOffsetsArr = committedOffsets.toLongArray();
       // Calculate the word index in the long array. Long size is 64.
+      final var wordSize = 64;
       final var relativeOffset = committed - initialOffset;
-      final var wordOfCommitted = (int) (relativeOffset / 64);
+      final var wordOfCommitted = (int) (relativeOffset / wordSize);
 
       // Copy from wordOfCommitted to the end: [..., wordOfCommitted, ...]
       final var newCommittedOffsetsArr = Arrays.copyOfRange(
@@ -305,7 +306,7 @@ public final class OffsetManager implements RecordDispatcherListener {
 
       // Re-create committedOffset BitSet and reset initialOffset.
       this.committedOffsets = BitSet.valueOf(newCommittedOffsetsArr);
-      this.initialOffset = committed;
+      this.initialOffset = committed - (relativeOffset % wordSize);
     }
   }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/knative-sandbox/eventing-kafka-broker/commit/88cf8e76b90a5a55208e88e800362e5dc331d283