### PR TITLE
Update the test script due to recent bump

### DIFF
--- a/openshift/patches/use_quay_images.patch
+++ b/openshift/patches/use_quay_images.patch
@@ -15,7 +15,7 @@ index f43cf83f7..5e77c37cc 100755
      spec:
        containers:
        - name: single-heartbeat
--        image: ko://knative.dev/eventing/test/test_images/heartbeats
+-        image: ko://knative.dev/eventing/cmd/heartbeats
 +        image: quay.io/openshift-knative/knative-eventing-sources-heartbeats:v0.13.2
          args:
          - --period=1


### PR DESCRIPTION
Based on upstream bump PR (3041), this script needs to be adjusted

**NOTE:** this is not about discussing the version, it's about correcting the changed `ko://` path that will be replaced.