### PR TITLE
Remove .cache directory in build-image Dockerfile to avoid permission issues with Go 1.19

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -9,5 +9,9 @@ RUN yum install -y kubectl httpd-tools
 
 RUN GOFLAGS="" go install github.com/mikefarah/yq/v3@latest
 
+# go install creates $GOPATH/.cache with root permissions, we delete it here
+# to avoid permission issues with the runtime users
+RUN rm -rf $GOPATH/.cache
+
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
We have some cache issues, since we updated to Go 1.19:
```
github.com/openshift-knative/serverless-operator/hack imports
	knative.dev/pkg/hack: open /go/.cache/39/392806b81c87ffe152fa7bcfd4abfdffdab0dbfae1a3d12b20605770c0f60b73-d: permission denied
```

This is, because "we" create the `$GOPATH/.cache` directory as root and later try to access it as the runtime user from openshift-ci.
As we don't really need the `.cache` directory, we can remove it in the build image.