### PR TITLE
[release-v1.9] Change version label

### DIFF
--- a/openshift/release/artifacts/eventing-kafka-broker.yaml
+++ b/openshift/release/artifacts/eventing-kafka-broker.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-kafka-broker-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
   annotations:
     knative.dev/example-checksum: "57a32008"
 data:
@@ -201,7 +201,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-broker-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   - apiGroups:
       - ""
@@ -234,7 +234,7 @@ metadata:
   name: knative-kafka-broker-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 ---
 
@@ -257,7 +257,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-broker-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-broker-data-plane
@@ -290,7 +290,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-dispatcher
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-broker-dispatcher
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -302,7 +302,7 @@ spec:
       name: kafka-broker-dispatcher
       labels:
         app: kafka-broker-dispatcher
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-broker-dispatcher
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -461,7 +461,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-broker-receiver
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -473,7 +473,7 @@ spec:
       name: kafka-broker-receiver
       labels:
         app: kafka-broker-receiver
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-broker-receiver
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -617,7 +617,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-broker-receiver
     app.kubernetes.io/name: knative-eventing
 spec:

--- a/openshift/release/artifacts/eventing-kafka-channel.yaml
+++ b/openshift/release/artifacts/eventing-kafka-channel.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-kafka-channel-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
   annotations:
     knative.dev/example-checksum: "6ce544b6"
 data:
@@ -200,7 +200,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channel-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   - apiGroups:
       - ""
@@ -233,7 +233,7 @@ metadata:
   name: knative-kafka-channel-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 ---
 
@@ -256,7 +256,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-channel-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-channel-data-plane
@@ -289,7 +289,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-dispatcher
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-channel-dispatcher
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -301,7 +301,7 @@ spec:
       name: kafka-channel-dispatcher
       labels:
         app: kafka-channel-dispatcher
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-channel-dispatcher
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -460,7 +460,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-receiver
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-channel-receiver
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -472,7 +472,7 @@ spec:
       name: kafka-channel-receiver
       labels:
         app: kafka-channel-receiver
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-channel-receiver
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -616,7 +616,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-receiver
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-channel-receiver
     app.kubernetes.io/name: knative-eventing
 spec:

--- a/openshift/release/artifacts/eventing-kafka-controller.yaml
+++ b/openshift/release/artifacts/eventing-kafka-controller.yaml
@@ -21,7 +21,7 @@ metadata:
   name: kafka-broker-config
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 data:
   default.topic.partitions: "10"
   default.topic.replication.factor: "3"
@@ -48,7 +48,7 @@ metadata:
   labels:
     duck.knative.dev/addressable: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 spec:
   group: eventing.knative.dev
   names:
@@ -229,7 +229,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
@@ -318,7 +318,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: eventing-kafka-source-observer
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:
@@ -350,7 +350,7 @@ metadata:
   name: config-kafka-source-defaults
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
   annotations:
     knative.dev/example-checksum: "b6ed351d"
 data:
@@ -411,7 +411,7 @@ metadata:
   name: kafka-channel-config
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 data:
   bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"
 ---
@@ -434,7 +434,7 @@ kind: CustomResourceDefinition
 metadata:
   name: kafkachannels.messaging.knative.dev
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
@@ -702,7 +702,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     knative.dev/crd-install: "true"
   name: consumergroups.internal.kafka.eventing.knative.dev
 spec:
@@ -770,7 +770,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     knative.dev/crd-install: "true"
   name: consumers.internal.kafka.eventing.knative.dev
 spec:
@@ -826,7 +826,7 @@ metadata:
   name: config-kafka-autoscaler
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 data:
     class: "keda.autoscaling.knative.dev"
     min-scale: "0"
@@ -856,7 +856,7 @@ metadata:
   name: config-kafka-descheduler
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 data:
     predicates: |+
                     []
@@ -919,7 +919,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
   name: config-kafka-leader-election
   namespace: knative-eventing
   annotations:
@@ -985,7 +985,7 @@ metadata:
   name: config-kafka-scheduler
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 data:
     predicates: |+
                   [
@@ -1027,7 +1027,7 @@ metadata:
   name: kafka-config-logging
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 data:
   config.xml: |
     <configuration>
@@ -1084,7 +1084,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-kafka-addressable-resolver
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -1127,7 +1127,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channelable-manipulator
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
@@ -1167,7 +1167,7 @@ kind: ClusterRole
 metadata:
   name: kafka-controller
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   - apiGroups:
       - ""
@@ -1446,7 +1446,7 @@ metadata:
   name: kafka-controller
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 ---
 
@@ -1469,7 +1469,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -1485,7 +1485,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller-addressable-resolver
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -1518,7 +1518,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-controller
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -1530,7 +1530,7 @@ spec:
       name: kafka-controller
       labels:
         app: kafka-controller
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-controller
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -1702,7 +1702,7 @@ kind: ClusterRole
 metadata:
   name: kafka-webhook-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:
@@ -1814,7 +1814,7 @@ metadata:
   name: kafka-webhook-eventing
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 ---
 
@@ -1837,7 +1837,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-webhook-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: kafka-webhook-eventing
@@ -1867,7 +1867,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 webhooks:
   - admissionReviewVersions: [ "v1", "v1beta1" ]
     clientConfig:
@@ -1898,7 +1898,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: pods.defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 webhooks:
   # Dispatcher pods webhook config.
   - admissionReviewVersions: [ "v1", "v1beta1" ]
@@ -1939,7 +1939,7 @@ metadata:
   name: kafka-webhook-eventing-certs
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -1961,7 +1961,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -1994,7 +1994,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-webhook-eventing
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -2005,7 +2005,7 @@ spec:
     metadata:
       labels:
         app: kafka-webhook-eventing
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-webhook-eventing
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -2097,7 +2097,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-webhook-eventing
     app.kubernetes.io/name: knative-eventing
 spec:

--- a/openshift/release/artifacts/eventing-kafka-post-install.yaml
+++ b/openshift/release/artifacts/eventing-kafka-post-install.yaml
@@ -20,7 +20,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   - apiGroups:
       - apps
@@ -236,7 +236,7 @@ metadata:
   name: knative-kafka-controller-post-install
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -257,7 +257,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   # Storage version upgrader needs to be able to patch CRDs.
   - apiGroups:
@@ -339,7 +339,7 @@ metadata:
   name: knative-kafka-storage-version-migrator
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 
 ---
 
@@ -348,7 +348,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-storage-version-migrator
@@ -379,7 +379,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-controller-post-install
@@ -410,7 +410,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller-post-install
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -418,7 +418,7 @@ spec:
     metadata:
       labels:
         app: kafka-controller-post-install
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -463,7 +463,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: "knative-kafka-storage-version-migrator"
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -471,7 +471,7 @@ spec:
     metadata:
       labels:
         app: "knative-kafka-storage-version-migrator"
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/openshift/release/artifacts/eventing-kafka-sink.yaml
+++ b/openshift/release/artifacts/eventing-kafka-sink.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-kafka-sink-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
   annotations:
     knative.dev/example-checksum: "a8ce4acb"
 data:
@@ -114,7 +114,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-sink-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   - apiGroups:
       - ""
@@ -147,7 +147,7 @@ metadata:
   name: knative-kafka-sink-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 ---
 
@@ -170,7 +170,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-sink-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-sink-data-plane
@@ -203,7 +203,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-sink-receiver
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -215,7 +215,7 @@ spec:
       name: kafka-sink-receiver
       labels:
         app: kafka-sink-receiver
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-sink-receiver
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -359,7 +359,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-sink-receiver
     app.kubernetes.io/name: knative-eventing
 spec:

--- a/openshift/release/artifacts/eventing-kafka-source.yaml
+++ b/openshift/release/artifacts/eventing-kafka-source.yaml
@@ -18,7 +18,7 @@ metadata:
   name: config-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
   annotations:
     knative.dev/example-checksum: "8157ecb1"
 data:
@@ -181,7 +181,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   - apiGroups:
       - ""
@@ -214,7 +214,7 @@ metadata:
   name: knative-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 ---
 
@@ -237,7 +237,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-source-data-plane
@@ -270,7 +270,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-source-dispatcher
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-source-dispatcher
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -284,7 +284,7 @@ spec:
       name: kafka-source-dispatcher
       labels:
         app: kafka-source-dispatcher
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-channel-dispatcher
         app.kubernetes.io/name: knative-eventing
         app.kubernetes.io/kind: kafka-dispatcher

--- a/openshift/release/artifacts/eventing-kafka.yaml
+++ b/openshift/release/artifacts/eventing-kafka.yaml
@@ -21,7 +21,7 @@ metadata:
   name: kafka-broker-config
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 data:
   default.topic.partitions: "10"
   default.topic.replication.factor: "3"
@@ -48,7 +48,7 @@ metadata:
   labels:
     duck.knative.dev/addressable: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 spec:
   group: eventing.knative.dev
   names:
@@ -229,7 +229,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
@@ -318,7 +318,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: eventing-kafka-source-observer
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:
@@ -350,7 +350,7 @@ metadata:
   name: config-kafka-source-defaults
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
   annotations:
     knative.dev/example-checksum: "b6ed351d"
 data:
@@ -411,7 +411,7 @@ metadata:
   name: kafka-channel-config
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 data:
   bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"
 ---
@@ -434,7 +434,7 @@ kind: CustomResourceDefinition
 metadata:
   name: kafkachannels.messaging.knative.dev
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
@@ -702,7 +702,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     knative.dev/crd-install: "true"
   name: consumergroups.internal.kafka.eventing.knative.dev
 spec:
@@ -770,7 +770,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     knative.dev/crd-install: "true"
   name: consumers.internal.kafka.eventing.knative.dev
 spec:
@@ -826,7 +826,7 @@ metadata:
   name: config-kafka-autoscaler
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 data:
     class: "keda.autoscaling.knative.dev"
     min-scale: "0"
@@ -856,7 +856,7 @@ metadata:
   name: config-kafka-descheduler
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 data:
     predicates: |+
                     []
@@ -919,7 +919,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
   name: config-kafka-leader-election
   namespace: knative-eventing
   annotations:
@@ -985,7 +985,7 @@ metadata:
   name: config-kafka-scheduler
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 data:
     predicates: |+
                   [
@@ -1027,7 +1027,7 @@ metadata:
   name: kafka-config-logging
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 data:
   config.xml: |
     <configuration>
@@ -1084,7 +1084,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-kafka-addressable-resolver
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -1127,7 +1127,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channelable-manipulator
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
@@ -1167,7 +1167,7 @@ kind: ClusterRole
 metadata:
   name: kafka-controller
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   - apiGroups:
       - ""
@@ -1446,7 +1446,7 @@ metadata:
   name: kafka-controller
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 ---
 
@@ -1469,7 +1469,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -1485,7 +1485,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller-addressable-resolver
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -1518,7 +1518,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-controller
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -1530,7 +1530,7 @@ spec:
       name: kafka-controller
       labels:
         app: kafka-controller
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-controller
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -1702,7 +1702,7 @@ kind: ClusterRole
 metadata:
   name: kafka-webhook-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:
@@ -1814,7 +1814,7 @@ metadata:
   name: kafka-webhook-eventing
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 ---
 
@@ -1837,7 +1837,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-webhook-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: kafka-webhook-eventing
@@ -1867,7 +1867,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 webhooks:
   - admissionReviewVersions: [ "v1", "v1beta1" ]
     clientConfig:
@@ -1898,7 +1898,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: pods.defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 webhooks:
   # Dispatcher pods webhook config.
   - admissionReviewVersions: [ "v1", "v1beta1" ]
@@ -1939,7 +1939,7 @@ metadata:
   name: kafka-webhook-eventing-certs
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -1961,7 +1961,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -1994,7 +1994,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-webhook-eventing
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -2005,7 +2005,7 @@ spec:
     metadata:
       labels:
         app: kafka-webhook-eventing
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-webhook-eventing
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -2097,7 +2097,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-webhook-eventing
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -2132,7 +2132,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   - apiGroups:
       - apps
@@ -2348,7 +2348,7 @@ metadata:
   name: knative-kafka-controller-post-install
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 # Copyright 2020 The Knative Authors
 #
@@ -2369,7 +2369,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   # Storage version upgrader needs to be able to patch CRDs.
   - apiGroups:
@@ -2451,7 +2451,7 @@ metadata:
   name: knative-kafka-storage-version-migrator
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 
 ---
 
@@ -2460,7 +2460,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-storage-version-migrator
@@ -2491,7 +2491,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-controller-post-install
@@ -2522,7 +2522,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller-post-install
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -2530,7 +2530,7 @@ spec:
     metadata:
       labels:
         app: kafka-controller-post-install
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -2575,7 +2575,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: "knative-kafka-storage-version-migrator"
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -2583,7 +2583,7 @@ spec:
     metadata:
       labels:
         app: "knative-kafka-storage-version-migrator"
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -2626,7 +2626,7 @@ metadata:
   name: config-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
   annotations:
     knative.dev/example-checksum: "8157ecb1"
 data:
@@ -2789,7 +2789,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   - apiGroups:
       - ""
@@ -2822,7 +2822,7 @@ metadata:
   name: knative-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 ---
 
@@ -2845,7 +2845,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-source-data-plane
@@ -2878,7 +2878,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-source-dispatcher
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-source-dispatcher
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -2892,7 +2892,7 @@ spec:
       name: kafka-source-dispatcher
       labels:
         app: kafka-source-dispatcher
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-channel-dispatcher
         app.kubernetes.io/name: knative-eventing
         app.kubernetes.io/kind: kafka-dispatcher
@@ -3048,7 +3048,7 @@ metadata:
   name: config-kafka-broker-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
   annotations:
     knative.dev/example-checksum: "57a32008"
 data:
@@ -3231,7 +3231,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-broker-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   - apiGroups:
       - ""
@@ -3264,7 +3264,7 @@ metadata:
   name: knative-kafka-broker-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 ---
 
@@ -3287,7 +3287,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-broker-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-broker-data-plane
@@ -3320,7 +3320,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-dispatcher
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-broker-dispatcher
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -3332,7 +3332,7 @@ spec:
       name: kafka-broker-dispatcher
       labels:
         app: kafka-broker-dispatcher
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-broker-dispatcher
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -3491,7 +3491,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-broker-receiver
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -3503,7 +3503,7 @@ spec:
       name: kafka-broker-receiver
       labels:
         app: kafka-broker-receiver
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-broker-receiver
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -3647,7 +3647,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-broker-receiver
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -3687,7 +3687,7 @@ metadata:
   name: config-kafka-channel-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
   annotations:
     knative.dev/example-checksum: "6ce544b6"
 data:
@@ -3869,7 +3869,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channel-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   - apiGroups:
       - ""
@@ -3902,7 +3902,7 @@ metadata:
   name: knative-kafka-channel-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 ---
 
@@ -3925,7 +3925,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-channel-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-channel-data-plane
@@ -3958,7 +3958,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-dispatcher
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-channel-dispatcher
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -3970,7 +3970,7 @@ spec:
       name: kafka-channel-dispatcher
       labels:
         app: kafka-channel-dispatcher
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-channel-dispatcher
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -4129,7 +4129,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-receiver
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-channel-receiver
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -4141,7 +4141,7 @@ spec:
       name: kafka-channel-receiver
       labels:
         app: kafka-channel-receiver
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-channel-receiver
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -4285,7 +4285,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-channel-receiver
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-channel-receiver
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -4325,7 +4325,7 @@ metadata:
   name: config-kafka-sink-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
   annotations:
     knative.dev/example-checksum: "a8ce4acb"
 data:
@@ -4421,7 +4421,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-sink-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 rules:
   - apiGroups:
       - ""
@@ -4454,7 +4454,7 @@ metadata:
   name: knative-kafka-sink-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 ---
 ---
 
@@ -4477,7 +4477,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-sink-data-plane
   labels:
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-sink-data-plane
@@ -4510,7 +4510,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-sink-receiver
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -4522,7 +4522,7 @@ spec:
       name: kafka-sink-receiver
       labels:
         app: kafka-sink-receiver
-        app.kubernetes.io/version: devel
+        app.kubernetes.io/version: v1.9
         app.kubernetes.io/component: kafka-sink-receiver
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -4666,7 +4666,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-sink-receiver
-    app.kubernetes.io/version: devel
+    app.kubernetes.io/version: v1.9
     app.kubernetes.io/component: kafka-sink-receiver
     app.kubernetes.io/name: knative-eventing
 spec:

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -30,7 +30,7 @@ function resolve_resources() {
       echo "---" >>"$resolved_file_name"
       sed -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(test/\)\(.*\)+\1\2 \3\4test-\5+g" \
         -e "s+ko://++" \
-        -e "s+kafka.eventing.knative.dev/release: devel+kafka.eventing.knative.dev/release: ${release}+" \
+        -e "s+app.kubernetes.io/version: devel+app.kubernetes.io/version: ${release}+" \
         -e "s+\${KNATIVE_KAFKA_DISPATCHER_IMAGE}+${image_prefix}-dispatcher:${image_tag}+" \
         -e "s+\${KNATIVE_KAFKA_RECEIVER_IMAGE}+${image_prefix}-receiver:${image_tag}+" \
         -e "s+\(.* image: \)\(knative.dev\)\(.*/\)\(.*\)+\1${image_prefix}-\4:${image_tag}+g" \


### PR DESCRIPTION
We changed the label to `app.kubernetes.io/version` from `kafka.eventing.knative.dev/release`