### PR TITLE
[release-v1.8] Add logs-exporter and watch-cm test images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CGO_ENABLED=0
 GOOS=linux
 # Ignore errors if there are no images.
 CONTROL_PLANE_IMAGES=./control-plane/cmd/kafka-controller ./control-plane/cmd/webhook-kafka ./control-plane/cmd/post-install
-TEST_IMAGES=$(shell find ./test/test_images ./vendor/knative.dev/reconciler-test/cmd ./vendor/knative.dev/eventing/test/test_images -mindepth 1 -maxdepth 1 -type d 2> /dev/null)
+TEST_IMAGES=$(shell find ./test/cmd ./test/test_images ./vendor/knative.dev/reconciler-test/cmd ./vendor/knative.dev/eventing/test/test_images -mindepth 1 -maxdepth 1 -type d 2> /dev/null)
 BRANCH=
 TEST=
 IMAGE=


### PR DESCRIPTION
The TEST_IMAGES variable is used for building multiarch image via Github action.