### PR TITLE
[release-v1.9] Conformance tests against MTChannelBasedBroker

### DIFF
--- a/test/e2e_new/main_test.go
+++ b/test/e2e_new/main_test.go
@@ -20,7 +20,6 @@
 package e2e_new
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -31,10 +30,7 @@ import (
 	_ "knative.dev/pkg/system/testing"
 	"knative.dev/pkg/test/zipkin"
 
-	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/reconciler-test/pkg/environment"
-
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 )
 
 // global is the singleton instance of GlobalEnvironment. It is used to parse
@@ -44,11 +40,6 @@ var global environment.GlobalEnvironment
 
 // TestMain is the first entry point for `go test`.
 func TestMain(m *testing.M) {
-	// Force the broker class to be configured properly
-	if broker.EnvCfg.BrokerClass != kafka.BrokerClass && broker.EnvCfg.BrokerClass != kafka.NamespacedBrokerClass {
-		panic(fmt.Errorf("KafkaBroker class '%s' is unknown. Specify 'BROKER_CLASS' env var", broker.EnvCfg.BrokerClass))
-	}
-
 	global = environment.NewStandardGlobalEnvironment()
 
 	// Run the tests.

--- a/test/rekt/resources/configmap/broker/broker_config.go
+++ b/test/rekt/resources/configmap/broker/broker_config.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"embed"
 
+	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkachannel"
 	"knative.dev/reconciler-test/pkg/feature"
 	"knative.dev/reconciler-test/pkg/manifest"
 )
@@ -65,5 +66,15 @@ func WithBootstrapServer(bootstrapServer string) manifest.CfgFn {
 func WithAuthSecret(authSecret string) manifest.CfgFn {
 	return func(cfg map[string]interface{}) {
 		cfg["authSecret"] = authSecret
+	}
+}
+
+func WithKafkaChannelMTBroker() manifest.CfgFn {
+	return func(cfg map[string]interface{}) {
+		cfg["kafkaChannel"] = map[string]interface{}{
+			"version":           kafkachannel.GVR().Version,
+			"numPartitions":     2,
+			"replicationFactor": 3,
+		}
 	}
 }

--- a/test/rekt/resources/configmap/broker/broker_config.yaml
+++ b/test/rekt/resources/configmap/broker/broker_config.yaml
@@ -30,3 +30,11 @@ data:
   {{ if .authSecret }}
   auth.secret.ref.name: "{{ .authSecret }}"
   {{ end }}
+  {{ if .kafkaChannel }}
+  channel-template-spec: |
+    apiVersion: messaging.knative.dev/{{ .kafkaChannel.version }}
+    kind: KafkaChannel
+    spec:
+      numPartitions: {{ .kafkaChannel.numPartitions }}
+      replicationFactor: {{ .kafkaChannel.replicationFactor }}
+  {{ end }}


### PR DESCRIPTION
This is a backport of [upstream commit](https://github.com/knative-sandbox/eventing-kafka-broker/commit/2973309cf3c34877059a956b28d7a734e84ecf76) which was supposed to get to midstream automatically but somehow didn't get there. 

This is required for finishing https://github.com/openshift-knative/serverless-operator/pull/2065