### PR TITLE
Remove leftover from version patch removal

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -6,7 +6,6 @@ source $(dirname $0)/resolve.sh
 
 GITHUB_ACTIONS=true $(dirname $0)/../../hack/update-codegen.sh
 git apply openshift/patches/disable-ko-publish-rekt.patch
-git apply openshift/patches/override-min-version.patch
 
 # Eventing core will bring the config tracing ConfigMap, so remove it from heret
 rm -f control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml


### PR DESCRIPTION
Seems the removed `override-min-version.patch` (from #709 ) was used in `generate-release.sh` too.