### PR TITLE
Add vertx modules of dispatcher and receiver

### DIFF
--- a/openshift/ci-operator/static-images/dispatcher/Dockerfile
+++ b/openshift/ci-operator/static-images/dispatcher/Dockerfile
@@ -22,12 +22,14 @@ COPY /data-plane/pom.xml .
 COPY /data-plane/.editorconfig .
 COPY /data-plane/core/pom.xml core/pom.xml
 COPY /data-plane/receiver/pom.xml receiver/pom.xml
+COPY /data-plane/receiver-vertx/pom.xml receiver-vertx/pom.xml
 COPY /data-plane/dispatcher/pom.xml dispatcher/pom.xml
+COPY /data-plane/dispatcher-vertx/pom.xml dispatcher-vertx/pom.xml
 COPY /data-plane/contract/pom.xml contract/pom.xml
 COPY /data-plane/mvnw .
 COPY /data-plane/.mvn/wrapper .mvn/wrapper
 
-# Install dependencies. Note: don't build a single submodule (recever or dispatcher) since it just slows down
+# Install dependencies. Note: don't build a single submodule (receiver or dispatcher) since it just slows down
 # consecutive builds.
 RUN ./mvnw install -am -DskipTests -Drelease -Dlicense.skip -Deditorconfig.skip --no-transfer-progress
 

--- a/openshift/ci-operator/static-images/receiver/Dockerfile
+++ b/openshift/ci-operator/static-images/receiver/Dockerfile
@@ -22,12 +22,14 @@ COPY /data-plane/pom.xml .
 COPY /data-plane/.editorconfig .
 COPY /data-plane/core/pom.xml core/pom.xml
 COPY /data-plane/receiver/pom.xml receiver/pom.xml
+COPY /data-plane/receiver-vertx/pom.xml receiver-vertx/pom.xml
 COPY /data-plane/dispatcher/pom.xml dispatcher/pom.xml
+COPY /data-plane/dispatcher-vertx/pom.xml dispatcher-vertx/pom.xml
 COPY /data-plane/contract/pom.xml contract/pom.xml
 COPY /data-plane/mvnw .
 COPY /data-plane/.mvn/wrapper .mvn/wrapper
 
-# Install dependencies. Note: don't build a single submodule (recever or dispatcher) since it just slows down
+# Install dependencies. Note: don't build a single submodule (receiver or dispatcher) since it just slows down
 # consecutive builds.
 RUN ./mvnw install -am -DskipTests -Drelease -Dlicense.skip -Deditorconfig.skip --no-transfer-progress
 


### PR DESCRIPTION
In https://github.com/knative-sandbox/eventing-kafka-broker/pull/3106 the dispatcher-vertx and receiver-vertx modules were added.

Should fix the CI issues from https://github.com/openshift-knative/eventing-kafka-broker/pull/705 (at least the image builds)