### PR TITLE
Use vertx module of receiver

### DIFF
--- a/openshift/ci-operator/static-images/receiver/Dockerfile
+++ b/openshift/ci-operator/static-images/receiver/Dockerfile
@@ -35,9 +35,9 @@ RUN ./mvnw install -am -DskipTests -Drelease -Dlicense.skip -Deditorconfig.skip 
 
 COPY /data-plane/ .
 
-RUN ./mvnw package -pl=receiver -Drelease -am -DskipTests -Deditorconfig.skip --no-transfer-progress
+RUN ./mvnw package -pl=receiver-vertx -Drelease -am -DskipTests -Deditorconfig.skip --no-transfer-progress
 
-RUN mkdir /app && cp /build/receiver/target/receiver-1.0-SNAPSHOT.jar /app/app.jar
+RUN mkdir /app && cp /build/receiver-vertx/target/receiver-vertx-1.0-SNAPSHOT.jar /app/app.jar
 
 # We use the generated JDK from the "builder" image, so we can just go with the ubi-minimal
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime as running


### PR DESCRIPTION
In https://github.com/knative-sandbox/eventing-kafka-broker/pull/3142 the receiver was split into the vertx and (for later loom) module. The vertx receiver is now available in the receiver-vertx module. This PR updates the dockerfile to use the receiver-vertx module.

CI issues from https://github.com/openshift-knative/eventing-kafka-broker/pull/718:
in receiver pod:
```
no main manifest attribute, in /app/app.jar
```