### PR TITLE
Cherry pick custom kafka topics changes

### DIFF
--- a/control-plane/cmd/kafka-controller/main.go
+++ b/control-plane/cmd/kafka-controller/main.go
@@ -96,7 +96,7 @@ func main() {
 		injection.NamedControllerConstructor{
 			Name: "channel-controller",
 			ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
-				return channel.NewController(ctx, channelEnv)
+				return channel.NewController(ctx, watcher, channelEnv)
 			},
 		},
 

--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml
@@ -47,4 +47,4 @@ data:
   controller.autoscaler: "disabled"
   triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
   brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
-  channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"
+  channels.topic.template: "knative-messaging-kafka.{{ .Namespace }}.{{ .Name }}"

--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml
@@ -4,7 +4,7 @@ metadata:
   name: config-kafka-features
   namespace: knative-eventing
   annotations:
-    knative.dev/example-checksum: "330d9f60"
+    knative.dev/example-checksum: "1192895d"
 data:
   _example: |-
     ################################
@@ -36,7 +36,15 @@ data:
     # The Go text/template used to generate consumergroup ID for triggers.
     # The template can reference the trigger Kubernetes metadata only.
     triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+    # The Go text/template used to generate topics for Brokers.
+    # The template can reference the broker Kubernetes metadata only.
+    brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+    # The Go text/template used to generate topics for Channels.
+    # The template can reference the channel Kubernetes metadata only.
+    channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"
   dispatcher.rate-limiter: "disabled"
   dispatcher.ordered-executor-metrics: "disabled"
   controller.autoscaler: "disabled"
   triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+  brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+  channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"

--- a/control-plane/pkg/apis/config/features_test.go
+++ b/control-plane/pkg/apis/config/features_test.go
@@ -51,7 +51,7 @@ func TestFlags_IsEnabled_ContainingFlag(t *testing.T) {
 
 func TestGetFlags(t *testing.T) {
 	_, example := cm.ConfigMapsFromTestFile(t, FlagsConfigName)
-	flags, err := newFeaturesConfigFromMap(example)
+	flags, err := NewFeaturesConfigFromMap(example)
 	require.NoError(t, err)
 
 	require.True(t, flags.IsDispatcherRateLimiterEnabled())
@@ -74,7 +74,7 @@ func TestStoreLoadWithConfigMap(t *testing.T) {
 	store.OnConfigChanged(exampleConfig)
 
 	have := FromContext(store.ToContext(context.Background()))
-	expected, _ := newFeaturesConfigFromMap(exampleConfig)
+	expected, _ := NewFeaturesConfigFromMap(exampleConfig)
 
 	require.Equal(t, expected.IsDispatcherRateLimiterEnabled(), have.IsDispatcherRateLimiterEnabled())
 	require.Equal(t, expected.IsDispatcherOrderedExecutorMetricsEnabled(), have.IsDispatcherOrderedExecutorMetricsEnabled())
@@ -111,7 +111,8 @@ func TestExecuteTriggersConsumerGroupTemplateDefault(t *testing.T) {
 
 func TestExecuteTriggersConsumerGroupTemplateOverride(t *testing.T) {
 	nc := DefaultFeaturesConfig()
-	nc.features.TriggersConsumerGroupTemplate, _ = template.New("custom-template").Parse("knative-trigger-{{ .Namespace }}-{{ .Name }}-{{ .UID }}")
+	customTemplate, _ := template.New("custom-template").Parse("knative-trigger-{{ .Namespace }}-{{ .Name }}-{{ .UID }}")
+	nc.features.TriggersConsumerGroupTemplate = *customTemplate
 
 	result, err := nc.ExecuteTriggersConsumerGroupTemplate(v1.ObjectMeta{
 		Name:      "trigger",
@@ -141,7 +142,8 @@ func TestExecuteBrokersTopicTemplateDefault(t *testing.T) {
 
 func TestExecuteBrokersTopicTemplateOverride(t *testing.T) {
 	nc := DefaultFeaturesConfig()
-	nc.features.BrokersTopicTemplate, _ = template.New("custom-template").Parse("knative-broker-{{ .Namespace }}-{{ .Name }}-{{ .UID }}")
+	customTemplate, _ := template.New("custom-template").Parse("knative-broker-{{ .Namespace }}-{{ .Name }}-{{ .UID }}")
+	nc.features.BrokersTopicTemplate = *customTemplate
 
 	result, err := nc.ExecuteBrokersTopicTemplate(v1.ObjectMeta{
 		Name:      "topic",
@@ -166,12 +168,13 @@ func TestExecuteChannelsTopicTemplateDefault(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	require.Equal(t, result, "knative-channel-namespace-topic")
+	require.Equal(t, result, "knative-messaging-kafka.namespace.topic")
 }
 
 func TestExecuteChannelsTopicTemplateOverride(t *testing.T) {
 	nc := DefaultFeaturesConfig()
-	nc.features.ChannelsTopicTemplate, _ = template.New("custom-template").Parse("knative-channel-{{ .Namespace }}-{{ .Name }}-{{ .UID }}")
+	customTemplate, _ := template.New("custom-template").Parse("knative-channel-{{ .Namespace }}-{{ .Name }}-{{ .UID }}")
+	nc.features.ChannelsTopicTemplate = *customTemplate
 
 	result, err := nc.ExecuteChannelsTopicTemplate(v1.ObjectMeta{
 		Name:      "topic",

--- a/control-plane/pkg/apis/config/features_test.go
+++ b/control-plane/pkg/apis/config/features_test.go
@@ -60,6 +60,11 @@ func TestGetFlags(t *testing.T) {
 	require.True(t, flags.IsControllerAutoscalerEnabled())
 	require.Len(t, flags.features.TriggersConsumerGroupTemplate.Tree.Root.Nodes, 4)
 	require.Equal(t, flags.features.TriggersConsumerGroupTemplate.Name(), "triggers.consumergroup.template")
+	require.Len(t, flags.features.BrokersTopicTemplate.Tree.Root.Nodes, 4)
+	require.Equal(t, flags.features.BrokersTopicTemplate.Name(), "brokers.topic.template")
+	require.Len(t, flags.features.ChannelsTopicTemplate.Tree.Root.Nodes, 4)
+	require.Equal(t, flags.features.ChannelsTopicTemplate.Name(), "channels.topic.template")
+
 }
 
 func TestStoreLoadWithConfigMap(t *testing.T) {
@@ -75,6 +80,8 @@ func TestStoreLoadWithConfigMap(t *testing.T) {
 	require.Equal(t, expected.IsDispatcherOrderedExecutorMetricsEnabled(), have.IsDispatcherOrderedExecutorMetricsEnabled())
 	require.Equal(t, expected.IsControllerAutoscalerEnabled(), have.IsControllerAutoscalerEnabled())
 	require.Equal(t, expected.features.TriggersConsumerGroupTemplate.Name(), have.features.TriggersConsumerGroupTemplate.Name())
+	require.Equal(t, expected.features.BrokersTopicTemplate.Name(), have.features.BrokersTopicTemplate.Name())
+	require.Equal(t, expected.features.ChannelsTopicTemplate.Name(), have.features.ChannelsTopicTemplate.Name())
 }
 
 func TestStoreLoadWithContext(t *testing.T) {
@@ -84,6 +91,8 @@ func TestStoreLoadWithContext(t *testing.T) {
 	require.False(t, have.IsDispatcherOrderedExecutorMetricsEnabled())
 	require.False(t, have.IsControllerAutoscalerEnabled())
 	require.Equal(t, have.features.TriggersConsumerGroupTemplate.Name(), "triggers.consumergroup.template")
+	require.Equal(t, have.features.BrokersTopicTemplate.Name(), "brokers.topic.template")
+	require.Equal(t, have.features.ChannelsTopicTemplate.Name(), "channels.topic.template")
 }
 
 func TestExecuteTriggersConsumerGroupTemplateDefault(t *testing.T) {
@@ -114,4 +123,64 @@ func TestExecuteTriggersConsumerGroupTemplateOverride(t *testing.T) {
 	}
 
 	require.Equal(t, result, "knative-trigger-namespace-trigger-138ac0ec-2694-4747-900d-45be3da5c9a9")
+}
+
+func TestExecuteBrokersTopicTemplateDefault(t *testing.T) {
+	nc := DefaultFeaturesConfig()
+	result, err := nc.ExecuteBrokersTopicTemplate(v1.ObjectMeta{
+		Name:      "topic",
+		Namespace: "namespace",
+		UID:       "138ac0ec-2694-4747-900d-45be3da5c9a9",
+	})
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, result, "knative-broker-namespace-topic")
+}
+
+func TestExecuteBrokersTopicTemplateOverride(t *testing.T) {
+	nc := DefaultFeaturesConfig()
+	nc.features.BrokersTopicTemplate, _ = template.New("custom-template").Parse("knative-broker-{{ .Namespace }}-{{ .Name }}-{{ .UID }}")
+
+	result, err := nc.ExecuteBrokersTopicTemplate(v1.ObjectMeta{
+		Name:      "topic",
+		Namespace: "namespace",
+		UID:       "138ac0ec-2694-4747-900d-45be3da5c9a9",
+	})
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, result, "knative-broker-namespace-topic-138ac0ec-2694-4747-900d-45be3da5c9a9")
+}
+
+func TestExecuteChannelsTopicTemplateDefault(t *testing.T) {
+	nc := DefaultFeaturesConfig()
+	result, err := nc.ExecuteChannelsTopicTemplate(v1.ObjectMeta{
+		Name:      "topic",
+		Namespace: "namespace",
+		UID:       "138ac0ec-2694-4747-900d-45be3da5c9a9",
+	})
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, result, "knative-channel-namespace-topic")
+}
+
+func TestExecuteChannelsTopicTemplateOverride(t *testing.T) {
+	nc := DefaultFeaturesConfig()
+	nc.features.ChannelsTopicTemplate, _ = template.New("custom-template").Parse("knative-channel-{{ .Namespace }}-{{ .Name }}-{{ .UID }}")
+
+	result, err := nc.ExecuteChannelsTopicTemplate(v1.ObjectMeta{
+		Name:      "topic",
+		Namespace: "namespace",
+		UID:       "138ac0ec-2694-4747-900d-45be3da5c9a9",
+	})
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, result, "knative-channel-namespace-topic-138ac0ec-2694-4747-900d-45be3da5c9a9")
 }

--- a/control-plane/pkg/apis/config/testdata/config-kafka-features.yaml
+++ b/control-plane/pkg/apis/config/testdata/config-kafka-features.yaml
@@ -9,3 +9,5 @@ data:
     dispatcher.ordered-executor-metrics: "enabled"
     controller.autoscaler: "enabled"
     triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+    brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+    channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"

--- a/control-plane/pkg/reconciler/broker/broker.go
+++ b/control-plane/pkg/reconciler/broker/broker.go
@@ -35,6 +35,7 @@ import (
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
 	coreconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/core/config"
@@ -48,9 +49,6 @@ import (
 )
 
 const (
-	// TopicPrefix is the Kafka Broker topic prefix - (topic name: knative-broker-<broker-namespace>-<broker-name>).
-	TopicPrefix = "knative-broker-"
-
 	// ExternalTopicAnnotation for using external kafka topic for the broker
 	ExternalTopicAnnotation = "kafka.eventing.knative.dev/external.topic"
 
@@ -72,8 +70,9 @@ type Reconciler struct {
 
 	BootstrapServers string
 
-	Prober  prober.Prober
-	Counter *counter.Counter
+	Prober            prober.Prober
+	Counter           *counter.Counter
+	KafkaFeatureFlags *apisconfig.KafkaFeatureFlags
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, broker *eventing.Broker) reconciler.Event {
@@ -271,7 +270,15 @@ func (r *Reconciler) reconcileBrokerTopic(broker *eventing.Broker, securityOptio
 		}
 	} else {
 		// no external topic, we create it
-		topicName = kafka.BrokerTopic(TopicPrefix, broker)
+		var existingTopic bool
+		// check if the broker already has reconciled with a topic name and use that if it exists
+		// otherwise, we create a new topic name from the broker topic template
+		if topicName, existingTopic = broker.Status.Annotations[kafka.TopicAnnotation]; !existingTopic {
+			topicName, err = r.KafkaFeatureFlags.ExecuteBrokersTopicTemplate(broker.ObjectMeta)
+			if err != nil {
+				return "", statusConditionManager.TopicsNotPresentOrInvalidErr([]string{topicName}, err)
+			}
+		}
 
 		topic, err := kafka.CreateTopicIfDoesntExist(kafkaClusterAdminClient, logger, topicName, topicConfig)
 		if err != nil {
@@ -463,7 +470,11 @@ func (r *Reconciler) finalizeNonExternalBrokerTopic(broker *eventing.Broker, sec
 	}
 	defer kafkaClusterAdminClient.Close()
 
-	topic, err := kafka.DeleteTopic(kafkaClusterAdminClient, kafka.BrokerTopic(TopicPrefix, broker))
+	topicName, ok := broker.Status.Annotations[kafka.TopicAnnotation]
+	if !ok {
+		return fmt.Errorf("no topic annotated on broker")
+	}
+	topic, err := kafka.DeleteTopic(kafkaClusterAdminClient, topicName)
 	if err != nil {
 		return err
 	}

--- a/control-plane/pkg/reconciler/broker/controller.go
+++ b/control-plane/pkg/reconciler/broker/controller.go
@@ -39,6 +39,7 @@ import (
 	podinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod"
 	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/counter"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
@@ -56,6 +57,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher, env *config.E
 	eventing.RegisterAlternateBrokerConditionSet(base.IngressConditionSet)
 
 	configmapInformer := configmapinformer.Get(ctx)
+	featureFlags := apisconfig.DefaultFeaturesConfig()
 
 	reconciler := &Reconciler{
 		Reconciler: &base.Reconciler{
@@ -73,6 +75,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher, env *config.E
 		ConfigMapLister:            configmapInformer.Lister(),
 		Env:                        env,
 		Counter:                    counter.NewExpiringCounter(ctx),
+		KafkaFeatureFlags:          featureFlags,
 	}
 
 	logger := logging.FromContext(ctx)
@@ -94,6 +97,12 @@ func NewController(ctx context.Context, watcher configmap.Watcher, env *config.E
 	reconciler.Prober = prober.NewAsync(ctx, http.DefaultClient, env.IngressPodPort, IPsLister, impl.EnqueueKey)
 
 	brokerInformer := brokerinformer.Get(ctx)
+
+	kafkaConfigStore := apisconfig.NewStore(ctx, func(name string, value *apisconfig.KafkaFeatureFlags) {
+		reconciler.KafkaFeatureFlags.Reset(value)
+		impl.GlobalResync(brokerInformer.Informer())
+	})
+	kafkaConfigStore.WatchConfigs(watcher)
 
 	brokerInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: kafka.BrokerClassFilter(),

--- a/control-plane/pkg/reconciler/broker/controller_test.go
+++ b/control-plane/pkg/reconciler/broker/controller_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/broker/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/eventing/v1/trigger/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
@@ -65,6 +66,10 @@ func TestNewController(t *testing.T) {
 		configmap.NewStaticWatcher(&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "cm",
+			},
+		}, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: apisconfig.FlagsConfigName,
 			},
 		}),
 		env,

--- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
@@ -46,6 +46,7 @@ import (
 	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
 	eventinglisters "knative.dev/eventing/pkg/client/listers/eventing/v1"
 
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/counter"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
@@ -86,6 +87,8 @@ type NamespacedReconciler struct {
 	ManifestivalClient mf.Client
 
 	DataplaneLifecycleLocksByNamespace util.LockMap[string]
+
+	KafkaFeatureFlags *apisconfig.KafkaFeatureFlags
 }
 
 func (r *NamespacedReconciler) ReconcileKind(ctx context.Context, broker *eventing.Broker) reconciler.Event {
@@ -238,6 +241,7 @@ func (r *NamespacedReconciler) createReconcilerForBrokerInstance(broker *eventin
 		BootstrapServers:           r.BootstrapServers,
 		Prober:                     r.Prober,
 		Counter:                    r.Counter,
+		KafkaFeatureFlags:          r.KafkaFeatureFlags,
 	}
 }
 

--- a/control-plane/pkg/reconciler/broker/namespaced_broker_test.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_broker_test.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/manifestival/client-go-client"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -57,6 +58,7 @@ import (
 	brokerreconciler "knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1/broker"
 	reconcilertesting "knative.dev/eventing/pkg/reconciler/testing/v1"
 
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/receiver"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
 	. "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/broker"
@@ -319,7 +321,10 @@ func namespacedBrokerFinalization(t *testing.T, format string, env config.Env) {
 				reconcilertesting.NewNamespace(BrokerNamespace, func(ns *corev1.Namespace) {
 					ns.UID = BrokerNamespaceUUID
 				}),
-				NewDeletedBroker(reconcilertesting.WithBrokerClass(kafka.NamespacedBrokerClass)),
+				NewDeletedBroker(
+					WithTopicStatusAnnotation(BrokerTopic()),
+					reconcilertesting.WithBrokerClass(kafka.NamespacedBrokerClass),
+				),
 				BrokerConfig(bootstrapServers, 20, 5),
 				NewConfigMapFromContract(&contract.Contract{
 					Resources: []*contract.Resource{
@@ -430,7 +435,8 @@ func useTableNamespaced(t *testing.T, table TableTest, env *config.Env) {
 			expectedTopicDetail = td.(sarama.TopicDetail)
 		}
 
-		expectedTopicName := fmt.Sprintf("%s%s-%s", TopicPrefix, BrokerNamespace, BrokerName)
+		expectedTopicName, err := apisconfig.DefaultFeaturesConfig().ExecuteBrokersTopicTemplate(metav1.ObjectMeta{Namespace: BrokerNamespace, Name: BrokerName})
+		require.NoError(t, err, "Failed to create broker topic name from feature flags")
 		if t, ok := row.OtherTestData[externalTopic]; ok {
 			expectedTopicName = t.(string)
 		}
@@ -484,6 +490,7 @@ func useTableNamespaced(t *testing.T, table TableTest, env *config.Env) {
 			Prober:                             proberMock,
 			ManifestivalClient:                 mfcMockClient,
 			DataplaneLifecycleLocksByNamespace: util.NewExpiringLockMap[string](ctx, time.Minute*30),
+			KafkaFeatureFlags:                  apisconfig.DefaultFeaturesConfig(),
 		}
 
 		r := brokerreconciler.NewReconciler(

--- a/control-plane/pkg/reconciler/broker/namespaced_controller.go
+++ b/control-plane/pkg/reconciler/broker/namespaced_controller.go
@@ -56,6 +56,7 @@ import (
 	serviceaccountinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
 	clusterrolebindinginformer "knative.dev/pkg/client/injection/kube/informers/rbac/v1/clusterrolebinding"
 
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
@@ -105,6 +106,7 @@ func NewNamespacedController(ctx context.Context, watcher configmap.Watcher, env
 		Counter:                            counter.NewExpiringCounter(ctx),
 		ManifestivalClient:                 mfc,
 		DataplaneLifecycleLocksByNamespace: util.NewExpiringLockMap[string](ctx, time.Minute*30),
+		KafkaFeatureFlags:                  apisconfig.DefaultFeaturesConfig(),
 	}
 
 	impl := brokerreconciler.NewImpl(ctx, reconciler, kafka.NamespacedBrokerClass, func(impl *controller.Impl) controller.Options {

--- a/control-plane/pkg/reconciler/broker/testdata/config-kafka-features.yaml
+++ b/control-plane/pkg/reconciler/broker/testdata/config-kafka-features.yaml
@@ -9,5 +9,5 @@ data:
     dispatcher.ordered-executor-metrics: "enabled"
     controller.autoscaler: "enabled"
     triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
-    brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
-    channels.topic.template: "knative-messaging-kafka.{{ .Namespace }}.{{ .Name }}"
+    brokers.topic.template: "custom-broker-template.{{ .Namespace }}-{{ .Name }}"
+    channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"

--- a/control-plane/pkg/reconciler/channel/channel.go
+++ b/control-plane/pkg/reconciler/channel/channel.go
@@ -48,6 +48,7 @@ import (
 	messagingv1beta1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/messaging/v1beta1"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/channel/resources"
 
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
 	coreconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/core/config"
@@ -61,7 +62,6 @@ import (
 
 const (
 	// TopicPrefix is the Kafka Channel topic prefix - (topic name: knative-messaging-kafka.<channel-namespace>.<channel-name>).
-	TopicPrefix                  = "knative-messaging-kafka"
 	DefaultDeliveryOrder         = contract.DeliveryOrder_ORDERED
 	NewChannelIngressServiceName = "kafka-channel-ingress"
 )
@@ -92,6 +92,8 @@ type Reconciler struct {
 	Prober prober.Prober
 
 	IngressHost string
+
+	KafkaFeatureFlags *apisconfig.KafkaFeatureFlags
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, channel *messagingv1beta1.KafkaChannel) reconciler.Event {
@@ -161,7 +163,20 @@ func (r *Reconciler) reconcileKind(ctx context.Context, channel *messagingv1beta
 		return fmt.Errorf("failed to track secret: %w", err)
 	}
 
-	topicName := kafka.ChannelTopic(TopicPrefix, channel)
+	if channel.Status.Annotations == nil {
+		channel.Status.Annotations = make(map[string]string)
+	}
+	// Check if there is an existing topic name for this channel. If there is, reconcile the channel with the existing name.
+	// If not, create a new topic name from the channel topic name template.
+	var topicName string
+	var existingTopic bool
+	if topicName, existingTopic = channel.Status.Annotations[kafka.TopicAnnotation]; !existingTopic {
+		topicName, err = r.KafkaFeatureFlags.ExecuteChannelsTopicTemplate(channel.ObjectMeta)
+		if err != nil {
+			return err
+		}
+	}
+	channel.Status.Annotations[kafka.TopicAnnotation] = topicName
 
 	kafkaClusterAdminSaramaConfig, err := kafka.GetSaramaConfig(saramaSecurityOption)
 	if err != nil {
@@ -432,7 +447,11 @@ func (r *Reconciler) finalizeKind(ctx context.Context, channel *messagingv1beta1
 	}
 	defer kafkaClusterAdminClient.Close()
 
-	topic, err := kafka.DeleteTopic(kafkaClusterAdminClient, kafka.ChannelTopic(TopicPrefix, channel))
+	topicName, ok := channel.Status.Annotations[kafka.TopicAnnotation]
+	if !ok {
+		return fmt.Errorf("no topic annotated on channel")
+	}
+	topic, err := kafka.DeleteTopic(kafkaClusterAdminClient, topicName)
 	if err != nil {
 		return err
 	}
@@ -503,9 +522,12 @@ func (r *Reconciler) reconcileInitialOffset(ctx context.Context, channel *messag
 		return nil
 	}
 
-	topicName := kafka.ChannelTopic(TopicPrefix, channel)
+	topicName, err := r.KafkaFeatureFlags.ExecuteChannelsTopicTemplate(channel.ObjectMeta)
+	if err != nil {
+		return err
+	}
 	groupID := consumerGroup(channel, sub)
-	_, err := r.InitOffsetsFunc(ctx, kafkaClient, kafkaClusterAdmin, []string{topicName}, groupID)
+	_, err = r.InitOffsetsFunc(ctx, kafkaClient, kafkaClusterAdmin, []string{topicName}, groupID)
 	return err
 }
 

--- a/control-plane/pkg/reconciler/channel/channel_test.go
+++ b/control-plane/pkg/reconciler/channel/channel_test.go
@@ -21,6 +21,11 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"text/template"
+
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Shopify/sarama"
 	"k8s.io/utils/pointer"
@@ -66,6 +71,8 @@ const (
 	TestExpectedDataNumPartitions = "TestExpectedDataNumPartitions"
 	TestExpectedReplicationFactor = "TestExpectedReplicationFactor"
 	TestExpectedRetentionDuration = "TestExpectedRetentionDuration"
+
+	kafkaFeatureFlags = "kafka-feature-flags"
 )
 
 var finalizerUpdatedEvent = Eventf(
@@ -82,6 +89,8 @@ var DefaultEnv = &config.Env{
 	SystemNamespace:             "knative-eventing",
 	ContractConfigMapFormat:     base.Json,
 }
+
+var customChannelTopicTemplate = customTemplate()
 
 func TestReconcileKind(t *testing.T) {
 
@@ -112,6 +121,7 @@ func TestReconcileKind(t *testing.T) {
 			Key:  testKey,
 			Objects: []runtime.Object{
 				NewChannel(
+					WithChannelTopicStatusAnnotation(defaultTopicName()),
 					WithInitKafkaChannelConditions,
 					WithDeletedTimeStamp),
 				NewConfigMapWithTextData(system.Namespace(), DefaultEnv.GeneralConfigMapName, map[string]string{
@@ -193,6 +203,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						ChannelAddressable(&env),
@@ -273,6 +284,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						ChannelAddressable(&env),
@@ -341,6 +353,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						StatusProbeFailed(prober.StatusNotReady),
@@ -410,6 +423,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						StatusProbeFailed(prober.StatusUnknown),
@@ -481,6 +495,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						WithSubscribers(Subscriber1(WithFreshSubscriber, WithNoSubscriberURI)),
@@ -557,6 +572,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						ChannelAddressable(&env),
@@ -638,6 +654,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						ChannelAddressable(&env),
@@ -719,6 +736,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						ChannelAddressable(&env),
@@ -800,6 +818,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						ChannelAddressable(&env),
@@ -898,6 +917,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						ChannelAddressable(&env),
@@ -1170,6 +1190,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						ChannelAddressable(&env),
@@ -1272,6 +1293,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						ChannelAddressable(&env),
@@ -1377,6 +1399,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						ChannelAddressable(&env),
@@ -1479,6 +1502,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						ChannelAddressable(&env),
@@ -1547,6 +1571,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						ChannelAddressable(&env),
@@ -1612,6 +1637,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusConfigParsed,
 						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusDataPlaneAvailable,
 						ChannelAddressable(&env),
@@ -1653,6 +1679,7 @@ func TestReconcileKind(t *testing.T) {
 						WithInitKafkaChannelConditions,
 						StatusDataPlaneAvailable,
 						StatusConfigParsed,
+						WithChannelTopicStatusAnnotation(ChannelTopic()),
 						StatusTopicReadyWithName(ChannelTopic()),
 						StatusConfigMapNotUpdatedReady(
 							"Failed to get contract data from ConfigMap: knative-eventing/kafka-channel-channels-subscriptions",
@@ -1673,6 +1700,81 @@ func TestReconcileKind(t *testing.T) {
 				),
 			},
 		},
+		{
+			Name: "Reconciled normal - custom topic template",
+			Objects: []runtime.Object{
+				NewChannel(),
+				NewService(),
+				ChannelReceiverPod(env.SystemNamespace, map[string]string{
+					base.VolumeGenerationAnnotationKey: "0",
+					"annotation_to_preserve":           "value_to_preserve",
+				}),
+				ChannelDispatcherPod(env.SystemNamespace, map[string]string{
+					base.VolumeGenerationAnnotationKey: "0",
+					"annotation_to_preserve":           "value_to_preserve",
+				}),
+				NewConfigMapWithTextData(system.Namespace(), DefaultEnv.GeneralConfigMapName, map[string]string{
+					kafka.BootstrapServersConfigMapKey: ChannelBootstrapServers,
+				}),
+			},
+			Key: testKey,
+			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapUpdate(env.DataPlaneConfigMapNamespace, env.ContractConfigMapName, env.ContractConfigMapFormat, &contract.Contract{
+					Generation: 1,
+					Resources: []*contract.Resource{
+						{
+							Uid:              ChannelUUID,
+							Topics:           []string{CustomTopic(customChannelTopicTemplate)},
+							BootstrapServers: ChannelBootstrapServers,
+							Reference:        ChannelReference(),
+							Ingress: &contract.Ingress{
+								Host: receiver.Host(ChannelNamespace, ChannelName),
+							},
+						},
+					},
+				}),
+				ChannelReceiverPodUpdate(env.SystemNamespace, map[string]string{
+					"annotation_to_preserve":           "value_to_preserve",
+					base.VolumeGenerationAnnotationKey: "1",
+				}),
+				ChannelDispatcherPodUpdate(env.SystemNamespace, map[string]string{
+					"annotation_to_preserve":           "value_to_preserve",
+					base.VolumeGenerationAnnotationKey: "1",
+				}),
+			},
+			SkipNamespaceValidation: true, // WantCreates compare the channel namespace with configmap namespace, so skip it
+			WantCreates: []runtime.Object{
+				NewConfigMapWithBinaryData(env.DataPlaneConfigMapNamespace, env.ContractConfigMapName, nil),
+				NewPerChannelService(DefaultEnv),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: NewChannel(
+						WithInitKafkaChannelConditions,
+						StatusConfigParsed,
+						StatusConfigMapUpdatedReady(&env),
+						WithChannelTopicStatusAnnotation(CustomTopic(customChannelTopicTemplate)),
+						StatusTopicReadyWithName(CustomTopic(customChannelTopicTemplate)),
+						StatusDataPlaneAvailable,
+						ChannelAddressable(&env),
+						StatusProbeSucceeded,
+					),
+				},
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
+			OtherTestData: map[string]interface{}{
+				kafkaFeatureFlags: newKafkaFeaturesConfigFromMap(&corev1.ConfigMap{
+					Data: map[string]string{
+						"channels.topic.template": "custom-channel-template.{{ .Namespace }}.{{ .Name }}",
+					},
+				}),
+			},
+		},
 	}
 
 	useTable(t, table, env)
@@ -1691,7 +1793,7 @@ func TestFinalizeKind(t *testing.T) {
 		{
 			Name: "Finalize normal - no auth",
 			Objects: []runtime.Object{
-				NewDeletedChannel(),
+				NewDeletedChannel(WithChannelTopicStatusAnnotation(defaultTopicName())),
 				NewConfigMapFromContract(&contract.Contract{
 					Generation: 1,
 					Resources: []*contract.Resource{
@@ -1750,6 +1852,13 @@ func useTable(t *testing.T, table TableTest, env config.Env) {
 			proberMock = p.(prober.Prober)
 		}
 
+		var featureFlags *apisconfig.KafkaFeatureFlags
+		if v, ok := row.OtherTestData[kafkaFeatureFlags]; ok {
+			featureFlags = v.(*apisconfig.KafkaFeatureFlags)
+		} else {
+			featureFlags = apisconfig.DefaultFeaturesConfig()
+		}
+
 		numPartitions := int32(1)
 		if v, ok := row.OtherTestData[TestExpectedDataNumPartitions]; ok {
 			numPartitions = v.(int32)
@@ -1770,6 +1879,11 @@ func useTable(t *testing.T, table TableTest, env config.Env) {
 		}
 
 		retentionMillisString := strconv.FormatInt(retentionDuration.Milliseconds(), 10)
+
+		expectedTopicName, err := featureFlags.ExecuteChannelsTopicTemplate(metav1.ObjectMeta{Name: ChannelName, Namespace: ChannelNamespace, UID: ChannelUUID})
+		if err != nil {
+			panic("failed to create expected topic name")
+		}
 
 		reconciler := &Reconciler{
 			Reconciler: &base.Reconciler{
@@ -1795,7 +1909,7 @@ func useTable(t *testing.T, table TableTest, env config.Env) {
 			},
 			NewKafkaClusterAdminClient: func(_ []string, _ *sarama.Config) (sarama.ClusterAdmin, error) {
 				return &kafkatesting.MockKafkaClusterAdmin{
-					ExpectedTopicName: ChannelTopic(),
+					ExpectedTopicName: expectedTopicName,
 					ExpectedTopicDetail: sarama.TopicDetail{
 						NumPartitions:     numPartitions,
 						ReplicationFactor: replicationFactor,
@@ -1806,8 +1920,9 @@ func useTable(t *testing.T, table TableTest, env config.Env) {
 					T: t,
 				}, nil
 			},
-			Prober:      proberMock,
-			IngressHost: network.GetServiceHostname(env.IngressName, env.SystemNamespace),
+			Prober:            proberMock,
+			IngressHost:       network.GetServiceHostname(env.IngressName, env.SystemNamespace),
+			KafkaFeatureFlags: featureFlags,
 		}
 
 		reconciler.Tracker = &FakeTracker{}
@@ -1834,4 +1949,25 @@ func patchFinalizers() clientgotesting.PatchActionImpl {
 	patch := `{"metadata":{"finalizers":["` + finalizerName + `"],"resourceVersion":""}}`
 	action.Patch = []byte(patch)
 	return action
+}
+
+func defaultTopicName() string {
+	topicName, err := apisconfig.DefaultFeaturesConfig().ExecuteChannelsTopicTemplate(metav1.ObjectMeta{Name: ChannelName, Namespace: ChannelNamespace})
+	if err != nil {
+		panic("failed to create default channel topic name")
+	}
+	return topicName
+}
+
+func customTemplate() *template.Template {
+	channelsTemplate, _ := template.New("channels.topic.template").Parse("custom-channel-template.{{ .Namespace }}.{{ .Name }}")
+	return channelsTemplate
+}
+
+func newKafkaFeaturesConfigFromMap(cm *corev1.ConfigMap) *apisconfig.KafkaFeatureFlags {
+	featureFlags, err := apisconfig.NewFeaturesConfigFromMap(cm)
+	if err != nil {
+		panic("failed to create kafka features from config map")
+	}
+	return featureFlags
 }

--- a/control-plane/pkg/reconciler/channel/controller_test.go
+++ b/control-plane/pkg/reconciler/channel/controller_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
 	_ "knative.dev/eventing-kafka-broker/control-plane/pkg/client/injection/informers/messaging/v1beta1/kafkachannel/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
@@ -31,6 +32,7 @@ import (
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
+	"knative.dev/pkg/configmap"
 	dynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	reconcilertesting "knative.dev/pkg/reconciler/testing"
 
@@ -62,6 +64,11 @@ func TestNewController(t *testing.T) {
 
 	controller := NewController(
 		ctx,
+		configmap.NewStaticWatcher(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: apisconfig.FlagsConfigName,
+			},
+		}),
 		configs,
 	)
 	if controller == nil {

--- a/control-plane/pkg/reconciler/channel/testdata/config-kafka-features.yaml
+++ b/control-plane/pkg/reconciler/channel/testdata/config-kafka-features.yaml
@@ -10,4 +10,4 @@ data:
     controller.autoscaler: "enabled"
     triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
     brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
-    channels.topic.template: "knative-messaging-kafka.{{ .Namespace }}.{{ .Name }}"
+    channels.topic.template: "custom-channel-template.{{ .Namespace }}.{{ .Name }}"

--- a/control-plane/pkg/reconciler/channel/v2/controllerv2_test.go
+++ b/control-plane/pkg/reconciler/channel/v2/controllerv2_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
 	_ "knative.dev/eventing-kafka-broker/control-plane/pkg/client/injection/informers/messaging/v1beta1/kafkachannel/fake"
 	_ "knative.dev/eventing/pkg/client/injection/informers/messaging/v1/subscription/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
@@ -32,6 +33,7 @@ import (
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
+	"knative.dev/pkg/configmap"
 	dynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	reconcilertesting "knative.dev/pkg/reconciler/testing"
 
@@ -65,6 +67,11 @@ func TestNewController(t *testing.T) {
 
 	controller := NewController(
 		ctx,
+		configmap.NewStaticWatcher(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: apisconfig.FlagsConfigName,
+			},
+		}),
 		configs,
 	)
 	if controller == nil {

--- a/control-plane/pkg/reconciler/testing/objects_broker.go
+++ b/control-plane/pkg/reconciler/testing/objects_broker.go
@@ -17,8 +17,10 @@
 package testing
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
+	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +39,7 @@ import (
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/prober"
 
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
 	. "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/broker"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/security"
@@ -56,11 +59,21 @@ const (
 )
 
 var (
-	BrokerTopics = []string{fmt.Sprintf("%s%s-%s", TopicPrefix, BrokerNamespace, BrokerName)}
+	kafkaFeatureFlags = apisconfig.DefaultFeaturesConfig()
+	BrokerTopics      = []string{getKafkaTopic()}
 )
 
 func BrokerTopic() string {
-	return fmt.Sprintf("%s%s-%s", TopicPrefix, BrokerNamespace, BrokerName)
+	return getKafkaTopic()
+}
+
+func CustomBrokerTopic(template *template.Template) string {
+	var result bytes.Buffer
+	err := template.Execute(&result, metav1.ObjectMeta{Namespace: BrokerNamespace, Name: BrokerName, UID: BrokerUUID})
+	if err != nil {
+		panic("Failed to create custom topic name")
+	}
+	return result.String()
 }
 
 // NewBroker creates a new Broker with broker class equals to kafka.BrokerClass.
@@ -291,7 +304,11 @@ func StatusBrokerConfigMapUpdatedReady(env *config.Env) func(broker *eventing.Br
 }
 
 func StatusBrokerTopicReady(broker *eventing.Broker) {
-	StatusTopicReadyWithName(kafka.BrokerTopic(TopicPrefix, broker))(broker)
+	topicName, err := kafkaFeatureFlags.ExecuteBrokersTopicTemplate(broker.ObjectMeta)
+	if err != nil {
+		panic("Failed to create broker topic name")
+	}
+	StatusTopicReadyWithName(topicName)(broker)
 }
 
 func StatusExternalBrokerTopicReady(topic string) func(broker *eventing.Broker) {
@@ -468,4 +485,12 @@ func BrokerConfigMapSecretAnnotation(name string) reconcilertesting.BrokerOption
 		}
 		broker.Status.Annotations[security.AuthSecretNameKey] = name
 	}
+}
+
+func getKafkaTopic() string {
+	topicName, err := kafkaFeatureFlags.ExecuteBrokersTopicTemplate(metav1.ObjectMeta{Namespace: BrokerNamespace, Name: BrokerName})
+	if err != nil {
+		panic("Failed to create broker topic name")
+	}
+	return topicName
 }

--- a/control-plane/pkg/reconciler/testing/objects_channel.go
+++ b/control-plane/pkg/reconciler/testing/objects_channel.go
@@ -17,8 +17,10 @@
 package testing
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,14 +34,14 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/network"
 
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
 	messagingv1beta1 "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/messaging/v1beta1"
+	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/channel/resources"
 
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/config"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/contract"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/base"
-	. "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/channel"
 
 	subscriptionv1 "knative.dev/eventing/pkg/reconciler/testing/v1"
 )
@@ -62,7 +64,21 @@ const (
 
 func ChannelTopic() string {
 	c := NewChannel()
-	return kafka.ChannelTopic(TopicPrefix, c)
+	topicName, err := apisconfig.DefaultFeaturesConfig().ExecuteChannelsTopicTemplate(c.ObjectMeta)
+	if err != nil {
+		panic("Failed to create channel topic name")
+	}
+	return topicName
+}
+
+func CustomTopic(template *template.Template) string {
+	c := NewChannel()
+	var result bytes.Buffer
+	err := template.Execute(&result, c.ObjectMeta)
+	if err != nil {
+		panic("Failed to create custom topic name")
+	}
+	return result.String()
 }
 
 func NewChannel(options ...KRShapedOption) *messagingv1beta1.KafkaChannel {
@@ -73,6 +89,10 @@ func NewChannel(options ...KRShapedOption) *messagingv1beta1.KafkaChannel {
 			UID:       ChannelUUID,
 		},
 	}
+	return applyOptionsToChannel(c, options...)
+}
+
+func applyOptionsToChannel(c *messagingv1beta1.KafkaChannel, options ...KRShapedOption) *messagingv1beta1.KafkaChannel {
 	for _, opt := range options {
 		opt(c)
 	}
@@ -217,6 +237,16 @@ func ChannelAddressable(env *config.Env) func(obj duckv1.KRShaped) {
 		}
 
 		channel.GetConditionSet().Manage(&channel.Status).MarkTrue(base.ConditionAddressable)
+	}
+}
+
+func WithChannelTopicStatusAnnotation(topicName string) func(obj duckv1.KRShaped) {
+	return func(obj duckv1.KRShaped) {
+		channel := obj.(*messagingv1beta1.KafkaChannel)
+		if channel.Status.Annotations == nil {
+			channel.Status.Annotations = make(map[string]string, 1)
+		}
+		channel.Status.Annotations[kafka.TopicAnnotation] = topicName
 	}
 }
 

--- a/test/config/100-config-kafka-features.yaml
+++ b/test/config/100-config-kafka-features.yaml
@@ -9,4 +9,4 @@ data:
   controller.autoscaler: "enabled"
   triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
   brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
-  channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"
+  channels.topic.template: "knative-messaging-kafka.{{ .Namespace }}.{{ .Name }}"

--- a/test/config/100-config-kafka-features.yaml
+++ b/test/config/100-config-kafka-features.yaml
@@ -8,3 +8,5 @@ data:
   dispatcher.ordered-executor-metrics: "enabled"
   controller.autoscaler: "enabled"
   triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+  brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+  channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"

--- a/test/rekt/features/kafka_sink.go
+++ b/test/rekt/features/kafka_sink.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
 	"knative.dev/eventing/test/rekt/resources/broker"
 	"knative.dev/eventing/test/rekt/resources/trigger"
 	"knative.dev/reconciler-test/pkg/environment"
@@ -34,8 +34,6 @@ import (
 
 	cetest "github.com/cloudevents/sdk-go/v2/test"
 
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/kafka"
-	brokerreconciler "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/broker"
 	testpkg "knative.dev/eventing-kafka-broker/test/pkg"
 	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkasink"
 	"knative.dev/eventing-kafka-broker/test/rekt/resources/kafkatopic"
@@ -63,13 +61,6 @@ func BrokerWithTriggersAndKafkaSink(env environment.Environment) *feature.Featur
 	sink := feature.MakeRandomK8sName("sink")
 	verifyMessagesJobName := feature.MakeRandomK8sName("verify-messages-job")
 
-	topic := kafka.BrokerTopic(brokerreconciler.TopicPrefix, &eventingv1.Broker{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      brokerName,
-			Namespace: env.Namespace(),
-		},
-	})
-
 	trigger1FilterType := "trigger-1"
 	trigger2FilterType := "trigger-2"
 
@@ -84,6 +75,10 @@ func BrokerWithTriggersAndKafkaSink(env environment.Environment) *feature.Featur
 	eventTrigger2.SetType(trigger2FilterType)
 
 	f := feature.NewFeatureNamed("Trigger with KafkaSink")
+	topic, err := apisconfig.DefaultFeaturesConfig().ExecuteBrokersTopicTemplate(metav1.ObjectMeta{Name: brokerName, Namespace: env.Namespace()})
+	if err != nil {
+		panic("failed to create broker topic name")
+	}
 
 	f.Setup("Install broker", broker.Install(brokerName, broker.WithEnvConfig()...))
 	f.Setup("Broker is ready", broker.IsReady(brokerName))


### PR DESCRIPTION
This PR cherry picks the changes from https://github.com/knative-sandbox/eventing-kafka-broker/pull/3157 and https://github.com/knative-sandbox/eventing-kafka-broker/pull/3162 

There were some interesting merge conflicts in the broker and channel unit tests because of the presence of TLS in the tests on the upstream repo, so it may be worth looking closely at those files to make sure everything is still correct (but the tests are passing locally for me now)