### PR TITLE
Updated yq command to get the tag properly on release-v1.9

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -12,7 +12,7 @@ git apply openshift/patches/override-min-version.patch
 rm -f control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml
 
 image_prefix="registry.ci.openshift.org/openshift/knative-eventing-kafka-broker"
-tag=$(yq r openshift/project.yaml project.tag)
+tag=$(yq -r .project.tag openshift/project.yaml)
 release=${tag/knative-/} # This is used by resolve_resources function so it's not unused as the IDE suggests
 
 echo "Release: $release"


### PR DESCRIPTION
This PR cherry picks a fix to the `yq` command in the `generate-release` script onto the `release-v1.9` branch