### PR TITLE
Use vertx module of dispatcher

### DIFF
--- a/openshift/ci-operator/static-images/dispatcher/Dockerfile
+++ b/openshift/ci-operator/static-images/dispatcher/Dockerfile
@@ -35,9 +35,9 @@ RUN ./mvnw install -am -DskipTests -Drelease -Dlicense.skip -Deditorconfig.skip 
 
 COPY /data-plane/ .
 
-RUN ./mvnw package -pl=dispatcher -Drelease -am -DskipTests -Deditorconfig.skip --no-transfer-progress
+RUN ./mvnw package -pl=dispatcher-vertx -Drelease -am -DskipTests -Deditorconfig.skip --no-transfer-progress
 
-RUN mkdir /app && cp /build/dispatcher/target/dispatcher-1.0-SNAPSHOT.jar /app/app.jar
+RUN mkdir /app && cp /build/dispatcher-vertx/target/dispatcher-vertx-1.0-SNAPSHOT.jar /app/app.jar
 
 # We use the generated JDK from the "builder" image, so we can just go with the ubi-minimal
 FROM registry.access.redhat.com/ubi8/openjdk-17-runtime as running


### PR DESCRIPTION
In https://github.com/knative-sandbox/eventing-kafka-broker/pull/3177 we switched to the dispatcher-vertx module