### PR TITLE
Increase PollTimings for TestBrokerConformance

### DIFF
--- a/test/e2e_new/broker_conformance_test.go
+++ b/test/e2e_new/broker_conformance_test.go
@@ -42,6 +42,7 @@ func TestBrokerConformance(t *testing.T) {
 		knative.WithLoggingConfig,
 		knative.WithTracingConfig,
 		k8s.WithEventListener,
+		environment.WithPollTimings(PollInterval, PollTimeout),
 		environment.Managed(t),
 	)
 


### PR DESCRIPTION
It might take longer than default 2 minutes to finish the tests and since all the steps run in parallel now the time starts to tick earlier.

Backport from upstream.