### PR TITLE
Add loom modules

### DIFF
--- a/openshift/ci-operator/static-images/dispatcher/Dockerfile
+++ b/openshift/ci-operator/static-images/dispatcher/Dockerfile
@@ -23,8 +23,10 @@ COPY /data-plane/.editorconfig .
 COPY /data-plane/core/pom.xml core/pom.xml
 COPY /data-plane/receiver/pom.xml receiver/pom.xml
 COPY /data-plane/receiver-vertx/pom.xml receiver-vertx/pom.xml
+COPY /data-plane/receiver-loom/pom.xml receiver-loom/pom.xml
 COPY /data-plane/dispatcher/pom.xml dispatcher/pom.xml
 COPY /data-plane/dispatcher-vertx/pom.xml dispatcher-vertx/pom.xml
+COPY /data-plane/dispatcher-loom/pom.xml dispatcher-loom/pom.xml
 COPY /data-plane/contract/pom.xml contract/pom.xml
 COPY /data-plane/mvnw .
 COPY /data-plane/.mvn/wrapper .mvn/wrapper

--- a/openshift/ci-operator/static-images/receiver/Dockerfile
+++ b/openshift/ci-operator/static-images/receiver/Dockerfile
@@ -23,8 +23,10 @@ COPY /data-plane/.editorconfig .
 COPY /data-plane/core/pom.xml core/pom.xml
 COPY /data-plane/receiver/pom.xml receiver/pom.xml
 COPY /data-plane/receiver-vertx/pom.xml receiver-vertx/pom.xml
+COPY /data-plane/receiver-loom/pom.xml receiver-loom/pom.xml
 COPY /data-plane/dispatcher/pom.xml dispatcher/pom.xml
 COPY /data-plane/dispatcher-vertx/pom.xml dispatcher-vertx/pom.xml
+COPY /data-plane/dispatcher-loom/pom.xml dispatcher-loom/pom.xml
 COPY /data-plane/contract/pom.xml contract/pom.xml
 COPY /data-plane/mvnw .
 COPY /data-plane/.mvn/wrapper .mvn/wrapper


### PR DESCRIPTION
We get build errors in CI (#737) due to the missing modules which are referenced in the poms:

```
INFO[2023-07-15T00:48:04Z] Build knative-eventing-kafka-broker-dispatcher failed, printing logs: 
...
[1/2] STEP 2/17: ENV "BUILD_LOGLEVEL"="0"
[1/2] STEP 3/17: WORKDIR /build
[1/2] STEP 4/17: COPY /data-plane/pom.xml .
[1/2] STEP 5/17: COPY /data-plane/.editorconfig .
[1/2] STEP 6/17: COPY /data-plane/core/pom.xml core/pom.xml
[1/2] STEP 7/17: COPY /data-plane/receiver/pom.xml receiver/pom.xml
[1/2] STEP 8/17: COPY /data-plane/receiver-vertx/pom.xml receiver-vertx/pom.xml
[1/2] STEP 9/17: COPY /data-plane/dispatcher/pom.xml dispatcher/pom.xml
[1/2] STEP 10/17: COPY /data-plane/dispatcher-vertx/pom.xml dispatcher-vertx/pom.xml
[1/2] STEP 11/17: COPY /data-plane/contract/pom.xml contract/pom.xml
[1/2] STEP 12/17: COPY /data-plane/mvnw .
[1/2] STEP 13/17: COPY /data-plane/.mvn/wrapper .mvn/wrapper
[1/2] STEP 14/17: RUN ./mvnw install -am -DskipTests -Drelease -Dlicense.skip -Deditorconfig.skip --no-transfer-progress
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] Child module /build/receiver-loom of /build/pom.xml does not exist @ 
[ERROR] Child module /build/dispatcher-loom of /build/pom.xml does not exist @ 
 @ 
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project dev.knative.eventing.kafka.broker:data-plane:1.0-SNAPSHOT (/build/pom.xml) has 2 errors
[ERROR]     Child module /build/receiver-loom of /build/pom.xml does not exist
[ERROR]     Child module /build/dispatcher-loom of /build/pom.xml does not exist
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
...
```