### PR TITLE
[release-v1.10] Unique secret names

### DIFF
--- a/openshift/patches/unique-secret-names.patch
+++ b/openshift/patches/unique-secret-names.patch
@@ -1,0 +1,49 @@
+diff --git a/vendor/knative.dev/eventing/pkg/utils/secret.go b/vendor/knative.dev/eventing/pkg/utils/secret.go
+index b8063edd9..f3cadedf5 100644
+--- a/vendor/knative.dev/eventing/pkg/utils/secret.go
++++ b/vendor/knative.dev/eventing/pkg/utils/secret.go
+@@ -34,6 +34,17 @@ import (
+ // It'll either return a pointer to the new Secret or and error indicating
+ // why it couldn't do it.
+ func CopySecret(corev1Input clientcorev1.CoreV1Interface, srcNS string, srcSecretName string, tgtNS string, svcAccount string) (*corev1.Secret, error) {
++	return CopySecretWithName(corev1Input,
++		srcNS,
++		srcSecretName,
++		tgtNS,
++		srcSecretName, /* Use same target name as source by default */
++		svcAccount)
++}
++
++// CopySecretWithName will copy a secret from one namespace into another.
++// Allows for specifying target secret name.
++func CopySecretWithName(corev1Input clientcorev1.CoreV1Interface, srcNS, srcSecretName, tgtNS, tgtSecretName, svcAccount string) (*corev1.Secret, error) {
+ 	tgtNamespaceSvcAcct := corev1Input.ServiceAccounts(tgtNS)
+ 	srcSecrets := corev1Input.Secrets(srcNS)
+ 	tgtNamespaceSecrets := corev1Input.Secrets(tgtNS)
+@@ -54,7 +65,7 @@ func CopySecret(corev1Input clientcorev1.CoreV1Interface, srcNS string, srcSecre
+ 		context.Background(),
+ 		&corev1.Secret{
+ 			ObjectMeta: metav1.ObjectMeta{
+-				Name: srcSecretName,
++				Name: tgtSecretName,
+ 			},
+ 			Data: srcSecret.Data,
+ 			Type: srcSecret.Type,
+@@ -72,14 +83,14 @@ func CopySecret(corev1Input clientcorev1.CoreV1Interface, srcNS string, srcSecre
+ 	}
+ 
+ 	for _, secret := range tgtSvcAccount.ImagePullSecrets {
+-		if secret.Name == srcSecretName {
++		if secret.Name == tgtSecretName {
+ 			return newSecret, nil
+ 		}
+ 	}
+ 	// Prevent overwriting existing imagePullSecrets
+-	patch := `[{"op":"add","path":"/imagePullSecrets/-","value":{"name":"` + srcSecretName + `"}}]`
++	patch := `[{"op":"add","path":"/imagePullSecrets/-","value":{"name":"` + tgtSecretName + `"}}]`
+ 	if len(tgtSvcAccount.ImagePullSecrets) == 0 {
+-		patch = `[{"op":"add","path":"/imagePullSecrets","value":[{"name":"` + srcSecretName + `"}]}]`
++		patch = `[{"op":"add","path":"/imagePullSecrets","value":[{"name":"` + tgtSecretName + `"}]}]`
+ 	}
+ 	_, err = tgtNamespaceSvcAcct.Patch(context.Background(), svcAccount, types.JSONPatchType,
+ 		[]byte(patch), metav1.PatchOptions{})

--- a/test/rekt/features/broker_deleted_recreated.go
+++ b/test/rekt/features/broker_deleted_recreated.go
@@ -200,10 +200,11 @@ func BrokerWithBogusConfig() *feature.Feature {
 	f := feature.NewFeatureNamed("delete broker with bogus config")
 
 	brokerName := feature.MakeRandomK8sName("broker")
+	secretName := feature.MakeRandomK8sName("sasl-secret")
 
 	f.Setup("install bogus configuration", bogus_config.Install)
 
-	f.Requirement("Create SASL secret", featuressteps.CopySecretInTestNamespace(system.Namespace(), "strimzi-sasl-secret"))
+	f.Requirement("Create SASL secret", featuressteps.CopySecretInTestNamespace(system.Namespace(), SASLSecretName, secretName))
 
 	f.Setup("install broker", broker.Install(
 		brokerName,

--- a/test/rekt/features/kafka_source.go
+++ b/test/rekt/features/kafka_source.go
@@ -56,8 +56,8 @@ import (
 )
 
 const (
-	saslSecretName = "strimzi-sasl-secret"
-	tlsSecretName  = "strimzi-tls-secret"
+	SASLSecretName = "strimzi-sasl-secret"
+	TLSSecretName  = "strimzi-tls-secret"
 	SASLMech       = "sasl"
 	TLSMech        = "tls"
 	PlainMech      = "plain"
@@ -299,6 +299,7 @@ func kafkaSourceFeature(name string,
 
 	receiver := feature.MakeRandomK8sName("eventshub-receiver")
 	sender := feature.MakeRandomK8sName("eventshub-sender")
+	secretName := feature.MakeRandomK8sName("secret")
 
 	f.Setup("install kafka topic", kafkatopic.Install(kafkaSourceCfg.topic))
 	f.Setup("topic is ready", kafkatopic.IsReady(kafkaSourceCfg.topic))
@@ -319,23 +320,23 @@ func kafkaSourceFeature(name string,
 
 	switch kafkaSourceCfg.authMech {
 	case TLSMech:
-		f.Setup("Create TLS secret", featuressteps.CopySecretInTestNamespace(system.Namespace(), tlsSecretName))
+		f.Setup("Create TLS secret", featuressteps.CopySecretInTestNamespace(system.Namespace(), TLSSecretName, secretName))
 		kafkaSourceOpts = append(kafkaSourceOpts, kafkasource.WithBootstrapServers(testingpkg.BootstrapServersSslArr),
-			kafkasource.WithTLSCACert(tlsSecretName, "ca.crt"),
-			kafkasource.WithTLSCert(tlsSecretName, "user.crt"),
-			kafkasource.WithTLSKey(tlsSecretName, "user.key"),
+			kafkasource.WithTLSCACert(secretName, "ca.crt"),
+			kafkasource.WithTLSCert(secretName, "user.crt"),
+			kafkasource.WithTLSKey(secretName, "user.key"),
 			kafkasource.WithTLSEnabled(),
-			kafkasource.WithTLSCACert(tlsSecretName, "ca.crt"),
+			kafkasource.WithTLSCACert(secretName, "ca.crt"),
 		)
 	case SASLMech:
-		f.Setup("Create SASL secret", featuressteps.CopySecretInTestNamespace(system.Namespace(), saslSecretName))
+		f.Setup("Create SASL secret", featuressteps.CopySecretInTestNamespace(system.Namespace(), SASLSecretName, secretName))
 		kafkaSourceOpts = append(kafkaSourceOpts, kafkasource.WithBootstrapServers(testingpkg.BootstrapServersSslSaslScramArr),
 			kafkasource.WithSASLEnabled(),
-			kafkasource.WithSASLUser(saslSecretName, "user"),
-			kafkasource.WithSASLPassword(saslSecretName, "password"),
-			kafkasource.WithSASLType(saslSecretName, "saslType"),
+			kafkasource.WithSASLUser(secretName, "user"),
+			kafkasource.WithSASLPassword(secretName, "password"),
+			kafkasource.WithSASLType(secretName, "saslType"),
 			kafkasource.WithTLSEnabled(),
-			kafkasource.WithTLSCACert(saslSecretName, "ca.crt"),
+			kafkasource.WithTLSCACert(secretName, "ca.crt"),
 		)
 	default:
 		kafkaSourceOpts = append(kafkaSourceOpts, kafkasource.WithBootstrapServers(testingpkg.BootstrapServersPlaintextArr))

--- a/test/rekt/features/kafka_source_create_secrets_after.go
+++ b/test/rekt/features/kafka_source_create_secrets_after.go
@@ -36,6 +36,8 @@ func CreateSecretsAfterKafkaSource() *feature.Feature {
 	topicName := feature.MakeRandomK8sName("topic") // A k8s name is also a valid topic name.
 	name := feature.MakeRandomK8sName("source")
 	sink := feature.MakeRandomK8sName("sink")
+	saslSecretName := feature.MakeRandomK8sName("sasl-secret")
+	tlsSecretName := feature.MakeRandomK8sName("tls-secret")
 
 	f.Setup("install kafka topic", kafkatopic.Install(topicName))
 	f.Setup("install a service", service.Install(sink,
@@ -53,8 +55,8 @@ func CreateSecretsAfterKafkaSource() *feature.Feature {
 	))
 	f.Setup("KafkaSource is not ready", k8s.IsNotReady(kafkasource.GVR(), name))
 
-	f.Requirement("Create TLS secret", featuressteps.CopySecretInTestNamespace(system.Namespace(), tlsSecretName))
-	f.Requirement("Create SASL secret", featuressteps.CopySecretInTestNamespace(system.Namespace(), saslSecretName))
+	f.Requirement("Create TLS secret", featuressteps.CopySecretInTestNamespace(system.Namespace(), TLSSecretName, tlsSecretName))
+	f.Requirement("Create SASL secret", featuressteps.CopySecretInTestNamespace(system.Namespace(), SASLSecretName, saslSecretName))
 
 	f.Assert("KafkaSource is ready", kafkasource.IsReady(name))
 


### PR DESCRIPTION
Backport from upstream.

*   Includes changes in vendor directory for knative/eventing and the patch that creates the changes if applied.

