### PR TITLE
[main] Mirror upstream branches

### DIFF
--- a/openshift/release/mirror-upstream-branches.sh
+++ b/openshift/release/mirror-upstream-branches.sh
@@ -17,32 +17,21 @@ cat >> "$TMPDIR"/midstream_branches <<EOF
 0.3
 EOF
 
-git branch --list -a "upstream/release-*" | cut -f3 -d'/' | cut -f2 -d'-' > "$TMPDIR"/upstream_branches
-git branch --list -a "openshift/release-*" | cut -f3 -d'/' | cut -f2 -d'v' | cut -f1,2 -d'.' >> "$TMPDIR"/midstream_branches
+git branch --list -a "upstream/release-1.*" | cut -f3 -d'/' | cut -f2 -d'-' > "$TMPDIR"/upstream_branches
+git branch --list -a "openshift/release-v1.*" | cut -f3 -d'/' | cut -f2 -d'v' | cut -f1,2 -d'.' >> "$TMPDIR"/midstream_branches
 
 sort -o "$TMPDIR"/midstream_branches "$TMPDIR"/midstream_branches
 sort -o "$TMPDIR"/upstream_branches "$TMPDIR"/upstream_branches
 comm -32 "$TMPDIR"/upstream_branches "$TMPDIR"/midstream_branches > "$TMPDIR"/new_branches
 
-branches=$(cat "$TMPDIR"/new_branches)
-UPSTREAM_BRANCHES=($branches)
-
-if [ "${#UPSTREAM_BRANCHES[@]}" == 0 ]; then
+UPSTREAM_BRANCH=$(cat "$TMPDIR"/new_branches)
+if [ -z "$UPSTREAM_BRANCH" ]; then
     echo "no new branch, exiting"
     exit 0
 fi
-
-echo "Found upstream branches: ${UPSTREAM_BRANCHES[@]}"
-
-for branch in "${UPSTREAM_BRANCHES[@]}"; do
-  upstream_tag="knative-v${branch}.0"
-  # First, try "knative-v" prefix. The upstream tags have a different naming scheme since 1.0
-  if ! git ls-remote --tags upstream | grep "${upstream_tag}" &>/dev/null; then
-    upstream_tag="v${branch}.0"
-  fi
-  midstream_branch="release-v${branch}"
-  openshift/release/create-release-branch.sh "$upstream_tag" "$midstream_branch"
-  # we would check the error code, but we 'set -e', so assume we're fine
-  git push openshift "$midstream_branch"
-done
-
+echo "found upstream branch: $UPSTREAM_BRANCH"
+readonly UPSTREAM_TAG="knative-v$UPSTREAM_BRANCH.0"
+readonly MIDSTREAM_BRANCH="release-v$UPSTREAM_BRANCH"
+openshift/release/create-release-branch.sh "$UPSTREAM_TAG" "$MIDSTREAM_BRANCH"
+# we would check the error code, but we 'set -e', so assume we're fine
+git push openshift "$MIDSTREAM_BRANCH"

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -9,6 +9,9 @@ REPO_OWNER_NAME="openshift-knative"
 REPO_BRANCH="release-next"
 REPO_BRANCH_CI="${REPO_BRANCH}-ci"
 
+# Check if there's an upstream release we need to mirror downstream
+openshift/release/mirror-upstream-branches.sh
+
 # Reset REPO_BRANCH to upstream/main.
 git fetch upstream main
 git checkout upstream/main -B ${REPO_BRANCH}


### PR DESCRIPTION
We used to not have this for this repository, I believe it's now time for having it

- copied working file from eventing-core midstream (https://github.com/openshift-knative/eventing/blob/main/openshift/release/mirror-upstream-branches.sh)
- call file in update-to-head.sh