### PR TITLE
Update snappy to latest by explicitly list it as a dependency

### DIFF
--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -152,6 +152,13 @@
         <version>${kafka.version}</version>
       </dependency>
 
+
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>1.1.10.1</version>
+      </dependency>
+
       <!-- Micrometer -->
       <dependency>
         <groupId>io.micrometer</groupId>


### PR DESCRIPTION
using newer version of snappy (`1.1.10.1`), instead of ` 1.1.8.4`.

Release notes of that version: https://github.com/xerial/snappy-java/releases/tag/v1.1.10.1

FWIW, the Quarkus team uses now exactly this too:
https://github.com/quarkusio/quarkus/blob/1a6227669a2a294fb0083e43469a7ef78ca16dba/bom/application/pom.xml#L151 


## Verification

run `mvn dependency:tree` to see it lists the above mentioned version
