### PR TITLE
[release-v1.9] Make SecretSpec field of consumers Auth optional

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_types.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_types.go
@@ -128,7 +128,7 @@ type Auth struct {
 	NetSpec *bindings.KafkaNetSpec
 	// Deprecated, use secret spec
 	AuthSpec   *eventingv1alpha1.Auth `json:"AuthSpec,omitempty"`
-	SecretSpec *SecretSpec
+	SecretSpec *SecretSpec            `json:"SecretSpec,omitempty"`
 }
 
 type SecretSpec struct {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/SRVKE-1508

This fix should be necessary only for `release-v1.9` branch because that's where SecretSpec is added. For 1.10 and later the webhook will not complain about the field.
We could port this change to newer branches to get rid of `SecretSpec: null` which doesn't hurt but it's redundant.