### PR TITLE
[release-v1.9] Fix slow consumergroup reconciliation under load

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_lifecycle.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_lifecycle.go
@@ -61,7 +61,10 @@ func (cg *ConsumerGroup) MarkReconcileConsumersFailedCondition(condition *apis.C
 		condition.GetMessage(),
 	)
 
-	return fmt.Errorf("consumers aren't ready, %v: %v", condition.GetReason(), condition.GetMessage())
+	// It is "normal" to have non-ready consumers, and we will get notified when their status change,
+	// so we don't need to return an error here which causes the object to be queued with an
+	// exponentially increasing delay.
+	return nil
 }
 
 func (cg *ConsumerGroup) MarkReconcileConsumersSucceeded() {

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup_test.go
@@ -399,7 +399,7 @@ func TestReconcileKind(t *testing.T) {
 					}, nil
 				}),
 			},
-			WantErr: true,
+			WantErr: false,
 			WantCreates: []runtime.Object{
 				NewConsumer(1,
 					ConsumerSpec(NewConsumerSpec(
@@ -465,7 +465,6 @@ func TestReconcileKind(t *testing.T) {
 			},
 			WantEvents: []string{
 				finalizerUpdatedEvent,
-				"Warning InternalError consumers aren't ready, ConsumerBinding: failed to bind resource to pod: EOF",
 			},
 		},
 		{


### PR DESCRIPTION
Cherry-pick of https://github.com/knative-extensions/eventing-kafka-broker/pull/3293