### PR TITLE
[release-v1.9] Clean up reserved from resources that have been scheduled

### DIFF
--- a/openshift/patches/cleanup_reserved_from_deleted_and_non_pending_vpods.patch
+++ b/openshift/patches/cleanup_reserved_from_deleted_and_non_pending_vpods.patch
@@ -1,0 +1,25 @@
+diff --git a/vendor/knative.dev/eventing/pkg/scheduler/statefulset/scheduler.go b/vendor/knative.dev/eventing/pkg/scheduler/statefulset/scheduler.go
+index 083767450..ed1defaa6 100644
+--- a/vendor/knative.dev/eventing/pkg/scheduler/statefulset/scheduler.go
++++ b/vendor/knative.dev/eventing/pkg/scheduler/statefulset/scheduler.go
+@@ -253,6 +253,20 @@ func (s *StatefulSetScheduler) scheduleVPod(vpod scheduler.VPod) ([]duckv1alpha1
+ 		return nil, err
+ 	}
+ 
++	// Clean up reserved from removed resources that don't appear in the vpod list anymore and have
++	// no pending resources.
++	reserved := make(map[types.NamespacedName]map[string]int32)
++	for k, v := range s.reserved {
++		if pendings, ok := state.Pending[k]; ok {
++			if pendings == 0 {
++				reserved[k] = map[string]int32{}
++			} else {
++				reserved[k] = v
++			}
++		}
++	}
++	s.reserved = reserved
++
+ 	logger.Debugw("scheduling", zap.Any("state", state))
+ 
+ 	existingPlacements := vpod.GetPlacements()

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -10,6 +10,7 @@ git apply openshift/patches/override-min-version.patch
 git apply openshift/patches/autoscaler_fix.patch
 git apply openshift/patches/remove_resource_version_check.patch
 git apply openshift/patches/autoscaler_leader_log.patch
+git apply openshift/patches/cleanup_reserved_from_deleted_and_non_pending_vpods.patch
 
 # Eventing core will bring the config tracing ConfigMap, so remove it from heret
 rm -f control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml

--- a/vendor/knative.dev/eventing/pkg/scheduler/statefulset/scheduler.go
+++ b/vendor/knative.dev/eventing/pkg/scheduler/statefulset/scheduler.go
@@ -253,6 +253,20 @@ func (s *StatefulSetScheduler) scheduleVPod(vpod scheduler.VPod) ([]duckv1alpha1
 		return nil, err
 	}
 
+	// Clean up reserved from removed resources that don't appear in the vpod list anymore and have
+	// no pending resources.
+	reserved := make(map[types.NamespacedName]map[string]int32)
+	for k, v := range s.reserved {
+		if pendings, ok := state.Pending[k]; ok {
+			if pendings == 0 {
+				reserved[k] = map[string]int32{}
+			} else {
+				reserved[k] = v
+			}
+		}
+	}
+	s.reserved = reserved
+
 	logger.Debugw("scheduling", zap.Any("state", state))
 
 	existingPlacements := vpod.GetPlacements()


### PR DESCRIPTION
In a recent testing run, we've noticed we have have a scheduled `ConsumerGroup` [1] (see placements) being considered having reserved replicas in a different pod [2].

That makes the scheduler think that there is no space but the autoscaler says we have enough space to hold every virtual replica.

[1]
```
$ k describe consumergroups -n ks-multi-ksvc-0 c9ee3490-5b4b-4d11-87af-8cb2219d9fe3
Name:         c9ee3490-5b4b-4d11-87af-8cb2219d9fe3
Namespace:    ks-multi-ksvc-0
...
Status:
  Conditions:
    Last Transition Time:  2023-09-06T19:58:27Z
    Reason:                Autoscaler is disabled
    Status:                True
    Type:                  Autoscaler
    Last Transition Time:  2023-09-06T21:41:13Z
    Status:                True
    Type:                  Consumers
    Last Transition Time:  2023-09-06T19:58:27Z
    Status:                True
    Type:                  ConsumersScheduled
    Last Transition Time:  2023-09-06T21:41:13Z
    Status:                True
    Type:                  Ready
  Observed Generation:     1
  Placements:
    Pod Name:      kafka-source-dispatcher-6
    Vreplicas:     4
    Pod Name:      kafka-source-dispatcher-7
    Vreplicas:     4
  Replicas:        8
  Subscriber Uri:  http://receiver5-2.ks-multi-ksvc-0.svc.cluster.local
Events:            <none>
```

[2]
```
    "ks-multi-ksvc-0/c9ee3490-5b4b-4d11-87af-8cb2219d9fe3": {
      "kafka-source-dispatcher-3": 8
    },
```