### PR TITLE
Added command to run reconciler tests with KEDA on midstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ test-reconciler:
 	sh openshift/e2e-rekt-tests.sh
 .PHONY: test-reconciler
 
+test-reconciler-keda:
+	sh test/keda-reconciler-tests.sh
+.PHONY: test-reconciler-keda
+
 # Requires ko 0.2.0 or newer.
 # Target used by github actions.
 test-images:


### PR DESCRIPTION
This adds a command to run the reconciler KEDA tests on midstream. @pierDipi I'm not sure if we want to merge this yet, as the tests will probably be failing until after they get fixed upstream, but I didn't want to forget about this so I'm opening it now.