### PR TITLE
[release-v1.11] Update snappy override to latest

### DIFF
--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -171,6 +171,12 @@
         <version>${kafka.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>1.1.10.5</version>
+      </dependency>
+
       <!-- Micrometer -->
       <dependency>
         <groupId>io.micrometer</groupId>


### PR DESCRIPTION
similar to https://github.com/openshift-knative/eventing-kafka-broker/pull/843 but adding the actual override (as done in https://github.com/openshift-knative/eventing-kafka-broker/pull/772)