### PR TITLE
Enable new-trigger-filter feature flag

### DIFF
--- a/openshift/knative-eventing.yaml
+++ b/openshift/knative-eventing.yaml
@@ -18,7 +18,7 @@ spec:
       delivery-timeout: "enabled"
       kreference-mapping: "disabled"
       strict-subscriber: "disabled"
-      new-trigger-filters: "disabled"
+      new-trigger-filters: "enabled"
     config-br-defaults:
       default-br-config: |
         clusterDefault:


### PR DESCRIPTION
The `new-trigger-filter` FF was enabled in upstream in https://github.com/knative/eventing/pull/7243. We should enable it for our tests as well.

Test on release next: https://github.com/openshift-knative/eventing-kafka-broker/pull/853