### PR TITLE
[release-v1.11] Allow skipping make generate-release in e2e_new_tests

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -5,6 +5,8 @@ export SYSTEM_NAMESPACE=$EVENTING_NAMESPACE
 export TRACING_NAMESPACE=$EVENTING_NAMESPACE
 export KNATIVE_DEFAULT_NAMESPACE=$EVENTING_NAMESPACE
 
+export SKIP_GENERATE_RELEASE=${SKIP_GENERATE_RELEASE:-false}
+
 default_test_image_template=$(
   cat <<-END
 {{- with .Name }}
@@ -108,7 +110,10 @@ function run_conformance_tests() {
 function run_e2e_new_tests() {
   export BROKER_CLASS="Kafka"
 
-  make generate-release
+  if [ "$SKIP_GENERATE_RELEASE" = false ]; then
+    make generate-release
+  fi
+
   images_file=$(dirname $(realpath "$0"))/images.yaml
   cat "${images_file}"
 


### PR DESCRIPTION
In SO CI the permission error will fail the test, so we need to skip in when running tests in that repository.

This is an example https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/2310/pull-ci-openshift-knative-serverless-operator-main-4.13-upstream-e2e-kafka-aws-ocp-413/1713907700934381568

Besides that, in that repository, the command is not necessary