### PR TITLE
[release-v1.11] Improve getting the script directory

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -25,10 +25,12 @@ default_test_image_template=$(
 END
 )
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 export TEST_IMAGE_TEMPLATE=${TEST_IMAGE_TEMPLATE:-$default_test_image_template}
 
 # shellcheck disable=SC1090
-source "$(dirname "$0")/../test/e2e-common.sh"
+source "${SCRIPT_DIR}/../test/e2e-common.sh"
 
 # Loops until duration (car) is exceeded or command (cdr) returns non-zero
 function timeout() {
@@ -114,7 +116,7 @@ function run_e2e_new_tests() {
     make generate-release
   fi
 
-  images_file=$(dirname $(realpath "$0"))/images.yaml
+  images_file="${SCRIPT_DIR}"/images.yaml
   cat "${images_file}"
 
   if [[ ${FIRST_EVENT_DELAY_ENABLED:-true} == true ]]; then


### PR DESCRIPTION
In https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/2310/pull-ci-openshift-knative-serverless-operator-main-4.13-upstream-e2e-kafka-aws-ocp-413/1714590471239503872 I'm getting 

```
cat: /go/src/knative.dev/eventing-kafka-broker/test/images.yaml: No such file or directory
```

because it using the wrong directory and as described here this the more resilient way of doing this https://stackoverflow.com/questions/59895/how-do-i-get-the-directory-where-a-bash-script-is-located-from-within-the-script