### PR TITLE
[release-v1.10] HTTP/2 disable patch from upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,10 +39,10 @@ require (
 	github.com/google/gofuzz v1.2.0
 	github.com/kedacore/keda/v2 v2.8.1
 	go.opencensus.io v0.23.0
-	knative.dev/eventing v0.37.4-0.20231012084230-37dc77d8856a
+	knative.dev/eventing v0.37.5
 	knative.dev/hack v0.0.0-20230417170854-f591fea109b3
-	knative.dev/pkg v0.0.0-20231011201526-df28feae6d34
-	knative.dev/reconciler-test v0.0.0-20231012155627-6eb37a768042
+	knative.dev/pkg v0.0.0-20231023160942-0c39ce4b3a7f
+	knative.dev/reconciler-test v0.0.0-20231023114053-616ce2cecb19
 	sigs.k8s.io/controller-runtime v0.12.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1530,10 +1530,10 @@ k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2 h1:GfD9OzL11kvZN5iArC6oTS7RTj7oJ
 k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 knative.dev/hack v0.0.0-20230417170854-f591fea109b3 h1:+W4WBOq83tfGXKhtv8OB/uJeYqze3zh69GKiz1ucuqk=
 knative.dev/hack v0.0.0-20230417170854-f591fea109b3/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
-knative.dev/pkg v0.0.0-20231011201526-df28feae6d34 h1:H+K37bEBZ2STSWMjCgrdilj38KKZGVxBbob22K99Y50=
-knative.dev/pkg v0.0.0-20231011201526-df28feae6d34/go.mod h1:ZRgzFBFmdBsARm6+Pkr9WRG8bXys8rYq64ELfLG6+9w=
-knative.dev/reconciler-test v0.0.0-20231012155627-6eb37a768042 h1:RtfD3Reg78YaiQd2l41xFWpa1Cg3O9eAogs8GiRrAgw=
-knative.dev/reconciler-test v0.0.0-20231012155627-6eb37a768042/go.mod h1:5eaMf3A7YtrddJul/ddiv3zOC4wPx40Ndsq4jq0oM/c=
+knative.dev/pkg v0.0.0-20231023160942-0c39ce4b3a7f h1:XCH1qZqW1riR8cjhMGjewxQXlWPrfgxeUorBjpC6lE4=
+knative.dev/pkg v0.0.0-20231023160942-0c39ce4b3a7f/go.mod h1:ZRgzFBFmdBsARm6+Pkr9WRG8bXys8rYq64ELfLG6+9w=
+knative.dev/reconciler-test v0.0.0-20231023114053-616ce2cecb19 h1:E7gYUPhZs4yOlBD8taIy7OBmVCsegNlggQcIPYIIFbg=
+knative.dev/reconciler-test v0.0.0-20231023114053-616ce2cecb19/go.mod h1:5eaMf3A7YtrddJul/ddiv3zOC4wPx40Ndsq4jq0oM/c=
 pgregory.net/rapid v0.3.3 h1:jCjBsY4ln4Atz78QoBWxUEvAHaFyNDQg9+WU62aCn1U=
 pgregory.net/rapid v0.3.3/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/vendor/knative.dev/reconciler-test/pkg/environment/namespace.go
+++ b/vendor/knative.dev/reconciler-test/pkg/environment/namespace.go
@@ -122,12 +122,26 @@ func (mr *MagicEnvironment) CreateNamespaceIfNeeded() error {
 			return fmt.Errorf("error copying the image pull Secret: %s", err)
 		}
 
-		_, err = c.CoreV1().ServiceAccounts(mr.namespace).Patch(context.Background(), sa.Name, types.StrategicMergePatchType,
-			[]byte(`{"imagePullSecrets":[{"name":"`+mr.imagePullSecretName+`"}]}`), metav1.PatchOptions{})
+		for _, secret := range sa.ImagePullSecrets {
+			if secret.Name == mr.imagePullSecretName {
+				return nil
+			}
+		}
+
+		// Prevent overwriting existing imagePullSecrets
+		patch := `[{"op":"add","path":"/imagePullSecrets/-","value":{"name":"` + mr.imagePullSecretName + `"}}]`
+		if len(sa.ImagePullSecrets) == 0 {
+			patch = `[{"op":"add","path":"/imagePullSecrets","value":[{"name":"` + mr.imagePullSecretName + `"}]}]`
+		}
+
+		_, err = c.CoreV1().ServiceAccounts(mr.namespace).Patch(context.Background(), sa.Name, types.JSONPatchType,
+			[]byte(patch), metav1.PatchOptions{})
 		if err != nil {
-			return fmt.Errorf("patch failed on NS/SA (%s/%s): %s", mr.namespace, sa.Name, err)
+			return fmt.Errorf("patch failed on NS/SA (%s/%s): %w",
+				mr.namespace, sa.Name, err)
 		}
 	}
+
 	return nil
 }
 

--- a/vendor/knative.dev/reconciler-test/pkg/eventshub/rbac/100-sa.yaml
+++ b/vendor/knative.dev/reconciler-test/pkg/eventshub/rbac/100-sa.yaml
@@ -17,3 +17,9 @@ kind: ServiceAccount
 metadata:
   name: {{ .name }}
   namespace: {{ .namespace }}
+{{ if .withPullSecrets }}
+imagePullSecrets:
+  {{ range $_, $value := .withPullSecrets.secrets }}
+  - name: {{ $value }}
+  {{ end }}
+{{ end }}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1231,7 +1231,7 @@ k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/strings/slices
 k8s.io/utils/trace
-# knative.dev/eventing v0.37.4-0.20231012084230-37dc77d8856a => github.com/openshift-knative/eventing v0.99.1-0.20230831170232-cf89b7eadfce
+# knative.dev/eventing v0.37.5 => github.com/openshift-knative/eventing v0.99.1-0.20230831170232-cf89b7eadfce
 ## explicit; go 1.19
 knative.dev/eventing/cmd/event_display
 knative.dev/eventing/cmd/heartbeats
@@ -1384,7 +1384,7 @@ knative.dev/eventing/test/upgrade/prober/wathola/sender
 ## explicit; go 1.18
 knative.dev/hack
 knative.dev/hack/shell
-# knative.dev/pkg v0.0.0-20231011201526-df28feae6d34
+# knative.dev/pkg v0.0.0-20231023160942-0c39ce4b3a7f
 ## explicit; go 1.18
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate
@@ -1496,7 +1496,7 @@ knative.dev/pkg/webhook/json
 knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
-# knative.dev/reconciler-test v0.0.0-20231012155627-6eb37a768042
+# knative.dev/reconciler-test v0.0.0-20231023114053-616ce2cecb19
 ## explicit; go 1.18
 knative.dev/reconciler-test/cmd/eventshub
 knative.dev/reconciler-test/pkg/environment


### PR DESCRIPTION
Basicially this PR just runs:
```
./hack/update-deps.sh --upgrade --release 1.10
```

followed by `make RELEASE...`