### PR TITLE
[release-v1.9] HTTP/2 disable patch from upstream

### DIFF
--- a/openshift/patches/011-http2-cve.patch
+++ b/openshift/patches/011-http2-cve.patch
@@ -1,0 +1,40 @@
+diff --git a/vendor/knative.dev/pkg/webhook/webhook.go b/vendor/knative.dev/pkg/webhook/webhook.go
+index 779d388d2..c1e237a4f 100644
+--- a/vendor/knative.dev/pkg/webhook/webhook.go
++++ b/vendor/knative.dev/pkg/webhook/webhook.go
+@@ -67,6 +67,17 @@ type Options struct {
+ 	// GracePeriod is how long to wait after failing readiness probes
+ 	// before shutting down.
+ 	GracePeriod time.Duration
++
++	// EnableHTTP2 enables HTTP2 for webhooks.
++	// Mitigate CVE-2023-44487 by disabling HTTP2 by default until the Go
++	// standard library and golang.org/x/net are fully fixed.
++	// Right now, it is possible for authenticated and unauthenticated users to
++	// hold open HTTP2 connections and consume huge amounts of memory.
++	// See:
++	// * https://github.com/kubernetes/kubernetes/pull/121120
++	// * https://github.com/kubernetes/kubernetes/issues/121197
++	// * https://github.com/golang/go/issues/63417#issuecomment-1758858612
++	EnableHTTP2 bool
+ }
+ 
+ // Operation is the verb being operated on
+@@ -219,10 +230,17 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
+ 		QuietPeriod: wh.Options.GracePeriod,
+ 	}
+ 
++	// If TLSNextProto is not nil, HTTP/2 support is not enabled automatically.
++	nextProto := map[string]func(*http.Server, *tls.Conn, http.Handler){}
++	if wh.Options.EnableHTTP2 {
++		nextProto = nil
++	}
++
+ 	server := &http.Server{
+ 		Handler:           drainer,
+ 		Addr:              fmt.Sprint(":", wh.Options.Port),
+ 		TLSConfig:         wh.tlsConfig,
++		TLSNextProto: nextProto,
+ 		ReadHeaderTimeout: time.Minute, //https://medium.com/a-journey-with-go/go-understand-and-mitigate-slowloris-attack-711c1b1403f6
+ 	}
+ 

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -12,6 +12,7 @@ git apply openshift/patches/remove_resource_version_check.patch
 git apply openshift/patches/autoscaler_leader_log.patch
 git apply openshift/patches/cleanup_reserved_from_deleted_and_non_pending_vpods.patch
 git apply openshift/patches/handle_overcommitted_pods.patch
+git apply openshift/patches/011-http2-cve.patch
 
 # Eventing core will bring the config tracing ConfigMap, so remove it from heret
 rm -f control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml

--- a/vendor/knative.dev/pkg/webhook/webhook.go
+++ b/vendor/knative.dev/pkg/webhook/webhook.go
@@ -67,6 +67,17 @@ type Options struct {
 	// GracePeriod is how long to wait after failing readiness probes
 	// before shutting down.
 	GracePeriod time.Duration
+
+	// EnableHTTP2 enables HTTP2 for webhooks.
+	// Mitigate CVE-2023-44487 by disabling HTTP2 by default until the Go
+	// standard library and golang.org/x/net are fully fixed.
+	// Right now, it is possible for authenticated and unauthenticated users to
+	// hold open HTTP2 connections and consume huge amounts of memory.
+	// See:
+	// * https://github.com/kubernetes/kubernetes/pull/121120
+	// * https://github.com/kubernetes/kubernetes/issues/121197
+	// * https://github.com/golang/go/issues/63417#issuecomment-1758858612
+	EnableHTTP2 bool
 }
 
 // Operation is the verb being operated on
@@ -219,10 +230,17 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
 		QuietPeriod: wh.Options.GracePeriod,
 	}
 
+	// If TLSNextProto is not nil, HTTP/2 support is not enabled automatically.
+	nextProto := map[string]func(*http.Server, *tls.Conn, http.Handler){}
+	if wh.Options.EnableHTTP2 {
+		nextProto = nil
+	}
+
 	server := &http.Server{
 		Handler:           drainer,
 		Addr:              fmt.Sprint(":", wh.Options.Port),
 		TLSConfig:         wh.tlsConfig,
+		TLSNextProto: nextProto,
 		ReadHeaderTimeout: time.Minute, //https://medium.com/a-journey-with-go/go-understand-and-mitigate-slowloris-attack-711c1b1403f6
 	}
 


### PR DESCRIPTION
Manually updated the `webhook.go` file to make it match to upstream's PR (https://github.com/knative/pkg/commit/b8c14ce9f90321c5a13ee5a41838a342343cc028)

