### PR TITLE
[release-v1.11] Injects Openshift CA trust bundle

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -226,9 +226,9 @@ public class ConsumerVerticleBuilder {
     }
 
   private PemTrustOptions openshiftPemTrustOptions() {
-    return new PemTrustOptions().addCertPath("/ocp-serverless-custom-certs/ca-bundle.crt");
+    // TODO: Go for all files
+    return new PemTrustOptions().addCertPath("/ocp-serverless-custom-certs/ca-bundle.crt/ca-bundle.crt");
   }
-
 
   private ResponseHandler createResponseHandler(final Vertx vertx) {
         if (consumerVerticleContext.getEgress().hasReplyUrl()) {


### PR DESCRIPTION
Openshift serverless always injects a CA-trust-bundle CM to a given path, we apply that crt/pem file to the webclient, via options API.