### PR TITLE
Add patch to copy openshift-trusted-cabundle CM to namespaced broker namespace

### DIFF
--- a/openshift/patches/namespaced_broker_copy_trustedca_cm.patch
+++ b/openshift/patches/namespaced_broker_copy_trustedca_cm.patch
@@ -1,0 +1,12 @@
+diff --git a/control-plane/pkg/reconciler/broker/namespaced_broker.go b/control-plane/pkg/reconciler/broker/namespaced_broker.go
+index 5e71fa6d0..4db94dede 100644
+--- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
++++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
+@@ -386,6 +386,7 @@ func (r *NamespacedReconciler) configMapsFromSystemNamespace(broker *eventing.Br
+ 		"config-kafka-broker-data-plane",
+ 		"config-tracing",
+ 		"kafka-config-logging",
++		"config-openshift-trusted-cabundle",
+ 	}
+ 	resources := make([]unstructured.Unstructured, 0, len(configMaps))
+ 	for _, name := range configMaps {


### PR DESCRIPTION
Currently some namespace broker e2e tests [fail](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_eventing-kafka-broker/905/pull-ci-openshift-knative-eventing-kafka-broker-release-next-413-test-reconciler-aws-ocp-413/1732199568130445312), as the kafka-broker-receiver pod does not come up due to:

```
{
    "apiVersion": "v1",
    "count": 1,
    "eventTime": null,
    "firstTimestamp": "2023-12-06T02:00:20Z",
    "involvedObject": {
        "apiVersion": "v1",
        "kind": "Pod",
        "name": "kafka-broker-dispatcher-5497cb57c7-nm7mn",
        "namespace": "test-mszpfxqr",
        "resourceVersion": "223646",
        "uid": "6d6556f8-85b8-420f-a9b1-31b9a0a8cc31"
    },
    "kind": "Event",
    "lastTimestamp": "2023-12-06T02:00:20Z",
    "message": "MountVolume.SetUp failed for volume \"config-openshift-trusted-cabundle-volume\" : failed to sync configmap cache: timed out waiting for the condition",
    "metadata": {
        "creationTimestamp": "2023-12-06T02:00:20Z",
        "name": "kafka-broker-dispatcher-5497cb57c7-nm7mn.179e1b917d6ee1f7",
        "namespace": "test-mszpfxqr",
        "resourceVersion": "223726",
        "uid": "b8706f99-5b7b-4445-881a-c3411ddc6858"
    },
    "reason": "FailedMount",
    "reportingComponent": "",
    "reportingInstance": "",
    "source": {
        "component": "kubelet",
        "host": "ip-10-0-160-236.ec2.internal"
    },
    "type": "Warning"
},
```

This is as because we don't copy the `config-openshift-trusted-cabundle` configmap into the target namespace while we inject the configmap into our deployments & replicasets (since https://github.com/openshift-knative/serverless-operator/pull/2396).

This PR addresses it and copies the  `config-openshift-trusted-cabundle` configmap in case of namespaced broker to the target namespace too.

Testrun in https://github.com/openshift-knative/eventing-kafka-broker/pull/906 (with another commit, which was merged already and fixed some conformance test failures) -> reconciler tests are the relevant ones

/cc @matzew @aliok 