### PR TITLE
[release-v1.12] Injects Openshift CA trust bundle

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -215,12 +215,18 @@ public class ConsumerVerticleBuilder {
     private WebClientOptions createWebClientOptionsFromCACerts(String CACerts) {
         if (CACerts != null && !CACerts.isEmpty()) {
             return new WebClientOptions(consumerVerticleContext.getWebClientOptions())
-                    .setPemTrustOptions(new PemTrustOptions().addCertValue(Buffer.buffer(CACerts)));
+                    .setPemTrustOptions(new PemTrustOptions(openshiftPemTrustOptions()).addCertValue(Buffer.buffer(CACerts)));
+
         }
-        return consumerVerticleContext.getWebClientOptions();
+        return consumerVerticleContext.getWebClientOptions().setPemTrustOptions(openshiftPemTrustOptions());
     }
 
-    private ResponseHandler createResponseHandler(final Vertx vertx) {
+  private PemTrustOptions openshiftPemTrustOptions() {
+    return new PemTrustOptions().addCertPath("/ocp-serverless-custom-certs/ca-bundle.crt");
+  }
+
+
+  private ResponseHandler createResponseHandler(final Vertx vertx) {
         if (consumerVerticleContext.getEgress().hasReplyUrl()) {
             return new ResponseToHttpEndpointHandler(new WebClientCloudEventSender(
                     vertx,


### PR DESCRIPTION
Openshift serverless always injects a CA-trust-bundle CM to a given path, we apply that crt/pem file to the webclient, via options API.

Same like #909  - but for 1.12