### PR TITLE
Increase hardcoded PollTimeout value to 8m

### DIFF
--- a/test/e2e_new/broker_test.go
+++ b/test/e2e_new/broker_test.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	PollInterval = 3 * time.Second
-	PollTimeout  = 4 * time.Minute
+	PollTimeout  = 8 * time.Minute
 )
 
 func TestBrokerDeletedRecreated(t *testing.T) {


### PR DESCRIPTION
to workaround flaking TestKafkaSourceDeletedFromContractConfigMaps