### PR TITLE
Use ubi9 jdk 21 base images for dispatcher & receiver

### DIFF
--- a/openshift/ci-operator/static-images/dispatcher/Dockerfile
+++ b/openshift/ci-operator/static-images/dispatcher/Dockerfile
@@ -42,7 +42,7 @@ RUN ./mvnw package -pl=dispatcher-vertx -Drelease -am -DskipTests -Deditorconfig
 RUN mkdir /app && cp /build/dispatcher-vertx/target/dispatcher-vertx-1.0-SNAPSHOT.jar /app/app.jar
 
 # We use the generated JDK from the "builder" image, so we can just go with the ubi-minimal
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime as running
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime as running
 
 EXPOSE 8080 8778 9779
 

--- a/openshift/ci-operator/static-images/dispatcher/Dockerfile
+++ b/openshift/ci-operator/static-images/dispatcher/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM quay.io/openshift-knative/17-jdk-centos7 as builder
+FROM registry.access.redhat.com/ubi9/openjdk-21 as builder
 
 WORKDIR /build
 

--- a/openshift/ci-operator/static-images/dispatcher/Dockerfile
+++ b/openshift/ci-operator/static-images/dispatcher/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi9/openjdk-21 as builder
+FROM registry.access.redhat.com/ubi8/openjdk-21 as builder
 
 WORKDIR /build
 
@@ -44,7 +44,7 @@ RUN ./mvnw package -pl=dispatcher-vertx -Drelease -am -DskipTests -Deditorconfig
 RUN mkdir /app && cp /build/dispatcher-vertx/target/dispatcher-vertx-1.0-SNAPSHOT.jar /app/app.jar
 
 # We use the generated JDK from the "builder" image, so we can just go with the ubi-minimal
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime as running
+FROM registry.access.redhat.com/ubi8/openjdk-21-runtime as running
 
 EXPOSE 8080 8778 9779
 

--- a/openshift/ci-operator/static-images/dispatcher/Dockerfile
+++ b/openshift/ci-operator/static-images/dispatcher/Dockerfile
@@ -18,6 +18,8 @@ FROM registry.access.redhat.com/ubi9/openjdk-21 as builder
 
 WORKDIR /build
 
+USER root
+
 COPY /data-plane/pom.xml .
 COPY /data-plane/.editorconfig .
 COPY /data-plane/core/pom.xml core/pom.xml

--- a/openshift/ci-operator/static-images/receiver/Dockerfile
+++ b/openshift/ci-operator/static-images/receiver/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM quay.io/openshift-knative/17-jdk-centos7 as builder
+FROM registry.access.redhat.com/ubi9/openjdk-21 as builder
 
 WORKDIR /build
 

--- a/openshift/ci-operator/static-images/receiver/Dockerfile
+++ b/openshift/ci-operator/static-images/receiver/Dockerfile
@@ -42,7 +42,7 @@ RUN ./mvnw package -pl=receiver-vertx -Drelease -am -DskipTests -Deditorconfig.s
 RUN mkdir /app && cp /build/receiver-vertx/target/receiver-vertx-1.0-SNAPSHOT.jar /app/app.jar
 
 # We use the generated JDK from the "builder" image, so we can just go with the ubi-minimal
-FROM registry.access.redhat.com/ubi8/openjdk-17-runtime as running
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime as running
 
 EXPOSE 8080 8778 9779
 

--- a/openshift/ci-operator/static-images/receiver/Dockerfile
+++ b/openshift/ci-operator/static-images/receiver/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi9/openjdk-21 as builder
+FROM registry.access.redhat.com/ubi8/openjdk-21 as builder
 
 WORKDIR /build
 
@@ -44,7 +44,7 @@ RUN ./mvnw package -pl=receiver-vertx -Drelease -am -DskipTests -Deditorconfig.s
 RUN mkdir /app && cp /build/receiver-vertx/target/receiver-vertx-1.0-SNAPSHOT.jar /app/app.jar
 
 # We use the generated JDK from the "builder" image, so we can just go with the ubi-minimal
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime as running
+FROM registry.access.redhat.com/ubi8/openjdk-21-runtime as running
 
 EXPOSE 8080 8778 9779
 

--- a/openshift/ci-operator/static-images/receiver/Dockerfile
+++ b/openshift/ci-operator/static-images/receiver/Dockerfile
@@ -18,6 +18,8 @@ FROM registry.access.redhat.com/ubi9/openjdk-21 as builder
 
 WORKDIR /build
 
+USER root
+
 COPY /data-plane/pom.xml .
 COPY /data-plane/.editorconfig .
 COPY /data-plane/core/pom.xml core/pom.xml


### PR DESCRIPTION
Use the ubi9 openjdk-21 images as base images for the builder and runtime.

Hint:
* Need to switch to the root user for the maven build in f436dfc53cc0b08f12b6398a065d8dab4d0ae61a (the previous used `quay.io/openshift-knative/17-jdk-centos7` image run under root too):
  ```
  $ docker run --rm -it quay.io/openshift-knative/17-jdk-centos7:latest id
  uid=0(root) gid=0(root) groups=0(root)
  ```

Test run in https://github.com/openshift-knative/eventing-kafka-broker/pull/928