### PR TITLE
[release-v1.11] Cert injection, rely on workload's subPath injection

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -227,7 +227,7 @@ public class ConsumerVerticleBuilder {
 
   private PemTrustOptions openshiftPemTrustOptions() {
     // TODO: Go for all files
-    return new PemTrustOptions().addCertPath("/ocp-serverless-custom-certs/ca-bundle.crt/ca-bundle.crt");
+    return new PemTrustOptions().addCertPath("/ocp-serverless-custom-certs/ca-bundle.crt");
   }
 
   private ResponseHandler createResponseHandler(final Vertx vertx) {


### PR DESCRIPTION
workloads now have `subPath` injection, so all files are just on the `/ocp-serverless-custom-certs` directory

/hold
depends on https://github.com/openshift-knative/serverless-operator/pull/2422 