### PR TITLE
1.10 reconciler timeouts backport

### DIFF
--- a/openshift/patches/reconciler-test-delete-resources-timeout-increase.patch
+++ b/openshift/patches/reconciler-test-delete-resources-timeout-increase.patch
@@ -1,0 +1,13 @@
+diff --git a/vendor/knative.dev/reconciler-test/pkg/feature/feature.go b/vendor/knative.dev/reconciler-test/pkg/feature/feature.go
+index c245012ff..933f50e79 100644
+--- a/vendor/knative.dev/reconciler-test/pkg/feature/feature.go
++++ b/vendor/knative.dev/reconciler-test/pkg/feature/feature.go
+@@ -229,7 +229,7 @@ func DeleteResources(ctx context.Context, t T, refs []corev1.ObjectReference) er
+ 
+ 	var lastResource corev1.ObjectReference // One still present resource
+ 
+-	err := wait.Poll(time.Second, 4*time.Minute, func() (bool, error) {
++	err := wait.Poll(time.Second, 8*time.Minute, func() (bool, error) {
+ 		for _, ref := range refs {
+ 			gv, err := schema.ParseGroupVersion(ref.APIVersion)
+ 			if err != nil {

--- a/vendor/knative.dev/reconciler-test/pkg/feature/feature.go
+++ b/vendor/knative.dev/reconciler-test/pkg/feature/feature.go
@@ -229,7 +229,7 @@ func DeleteResources(ctx context.Context, t T, refs []corev1.ObjectReference) er
 
 	var lastResource corev1.ObjectReference // One still present resource
 
-	err := wait.Poll(time.Second, 4*time.Minute, func() (bool, error) {
+	err := wait.Poll(time.Second, 8*time.Minute, func() (bool, error) {
 		for _, ref := range refs {
 			gv, err := schema.ParseGroupVersion(ref.APIVersion)
 			if err != nil {


### PR DESCRIPTION
workaround for TestKafkaSourceDeletedFromContractConfigMaps timeouts on cleanup

on 1.11 we backported reconciler-test https://github.com/openshift-knative/eventing-kafka-broker/commit/8feed0c277afd4a303ce52ade6d3420eb9c545e8 , but let's keep a simpler patch for 1.10