### PR TITLE
[release-v1.11] Revert 'logger bump' backport from upstream/main and go to latest 1.2.x logback

### DIFF
--- a/data-plane/THIRD-PARTY.txt
+++ b/data-plane/THIRD-PARTY.txt
@@ -1,7 +1,7 @@
 
 Lists of 230 third-party dependencies.
-     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Classic Module (ch.qos.logback:logback-classic:1.4.14 - http://logback.qos.ch/logback-classic)
-     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Core Module (ch.qos.logback:logback-core:1.4.14 - http://logback.qos.ch/logback-core)
+     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Classic Module (ch.qos.logback:logback-classic:1.2.11 - http://logback.qos.ch/logback-classic)
+     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Core Module (ch.qos.logback:logback-core:1.2.11 - http://logback.qos.ch/logback-core)
      (Apache License 2.0) brotli4j (com.aayushatharva.brotli4j:brotli4j:1.12.0 - https://github.com/hyperxpro/Brotli4j/brotli4j)
      (Apache License 2.0) native-linux-x86_64 (com.aayushatharva.brotli4j:native-linux-x86_64:1.12.0 - https://github.com/hyperxpro/Brotli4j/natives/native-linux-x86_64)
      (Apache License 2.0) service (com.aayushatharva.brotli4j:service:1.12.0 - https://github.com/hyperxpro/Brotli4j/service)
@@ -224,8 +224,8 @@ Lists of 230 third-party dependencies.
      (Apache-2.0) Scala Library (org.scala-lang:scala-library:2.12.15 - https://www.scala-lang.org/)
      (Apache-2.0) scala-collection-compat (org.scala-lang.modules:scala-collection-compat_2.12:2.6.0 - http://www.scala-lang.org/)
      (Apache-2.0) scala-java8-compat (org.scala-lang.modules:scala-java8-compat_2.12:1.0.2 - http://www.scala-lang.org/)
-     (MIT License) SLF4J API Module (org.slf4j:slf4j-api:2.0.4 - http://www.slf4j.org)
-     (MIT License) SLF4J NOP Binding (org.slf4j:slf4j-nop:2.0.4 - http://www.slf4j.org)
+     (MIT License) SLF4J API Module (org.slf4j:slf4j-api:1.7.36 - http://www.slf4j.org)
+     (MIT License) SLF4J NOP Binding (org.slf4j:slf4j-nop:1.7.36 - http://www.slf4j.org)
      (Apache License, Version 2.0) SnakeYAML Engine (org.snakeyaml:snakeyaml-engine:2.6 - https://bitbucket.org/snakeyaml/snakeyaml-engine)
      (Apache License 2.0) wildfly-common (org.wildfly.common:wildfly-common:1.5.4.Final-format-001 - http://www.jboss.org/wildfly-common)
      (Apache-2.0) snappy-java (org.xerial.snappy:snappy-java:1.1.10.5 - https://github.com/xerial/snappy-java)

--- a/data-plane/THIRD-PARTY.txt
+++ b/data-plane/THIRD-PARTY.txt
@@ -1,7 +1,7 @@
 
 Lists of 230 third-party dependencies.
-     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Classic Module (ch.qos.logback:logback-classic:1.2.11 - http://logback.qos.ch/logback-classic)
-     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Core Module (ch.qos.logback:logback-core:1.2.11 - http://logback.qos.ch/logback-core)
+     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Classic Module (ch.qos.logback:logback-classic:1.2.13 - http://logback.qos.ch/logback-classic)
+     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Core Module (ch.qos.logback:logback-core:1.2.13 - http://logback.qos.ch/logback-core)
      (Apache License 2.0) brotli4j (com.aayushatharva.brotli4j:brotli4j:1.12.0 - https://github.com/hyperxpro/Brotli4j/brotli4j)
      (Apache License 2.0) native-linux-x86_64 (com.aayushatharva.brotli4j:native-linux-x86_64:1.12.0 - https://github.com/hyperxpro/Brotli4j/natives/native-linux-x86_64)
      (Apache License 2.0) service (com.aayushatharva.brotli4j:service:1.12.0 - https://github.com/hyperxpro/Brotli4j/service)

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -50,8 +50,8 @@
     <jackson.version>2.14.1</jackson.version>
     <protobuf.version>3.20.3</protobuf.version>
     <bucket4j.version>7.4.0</bucket4j.version>
-    <slf4j.version>2.0.4</slf4j.version>
-    <ch.qos.logback.version>1.4.14</ch.qos.logback.version>
+    <slf4j.version>1.7.36</slf4j.version>
+    <ch.qos.logback.version>1.2.11</ch.qos.logback.version>
     <net.logstash.logback.encoder.version>7.2</net.logstash.logback.encoder.version>
     <assertj.version>3.22.0</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -51,7 +51,7 @@
     <protobuf.version>3.20.3</protobuf.version>
     <bucket4j.version>7.4.0</bucket4j.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <ch.qos.logback.version>1.2.11</ch.qos.logback.version>
+    <ch.qos.logback.version>1.2.13</ch.qos.logback.version>
     <net.logstash.logback.encoder.version>7.2</net.logstash.logback.encoder.version>
     <assertj.version>3.22.0</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>


### PR DESCRIPTION
This reverts commit a0c2dea9f1dc69b13140c1eef524984926be556e **_AND_** goes to latest of `1.2.x` of logback

