### PR TITLE
TestBrokerWithConfig waits for Topic in Requirement phase

### DIFF
--- a/test/rekt/features/broker_config.go
+++ b/test/rekt/features/broker_config.go
@@ -55,7 +55,7 @@ func BrokerWithCustomReplicationFactorAndNumPartitions(env environment.Environme
 	if err != nil {
 		panic("failed to create broker topic name")
 	}
-	f.Setup("Topic is ready", kafkatopic.IsReady(topic))
+	f.Requirement("Topic is ready", kafkatopic.IsReady(topic))
 
 	f.Assert("Replication factor", kafkatopic.HasReplicationFactor(topic, replicationFactor))
 	f.Assert("Number of partitions", kafkatopic.HasNumPartitions(topic, numPartitions))


### PR DESCRIPTION
Backport from upstream.

When running many tests in parallel, waiting for the Topic might start much earlier than creating the Broker/Topic and it can time out (see below). This change ensures that waiting for the topic starts later.
```
=== CONT
TestBrokerWithConfig/Broker_KafkaTopic_config_from_Broker_configmap/Setup/Topic_is_ready
wait.go:136: kafka knative-broker-test-msvvevxa-broker-dtbsqwrn not
found kafkatopics.kafka.strimzi.io
"knative-broker-test-msvvevxa-broker-dtbsqwrn" not found
topic.go:73: kafka.strimzi.io/v1beta2, Resource=kafkatopics did not
become ready, timed out waiting for the condition
```