### PR TITLE
[WIP] chmod for update-cert-manager.sh in source-image Dockerfile

### DIFF
--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -2,4 +2,6 @@
 
 FROM src
 
-RUN chmod +x vendor/k8s.io/code-generator/generate-groups.sh vendor/knative.dev/pkg/hack/generate-knative.sh || true
+RUN chmod +x vendor/k8s.io/code-generator/generate-groups.sh \
+             vendor/knative.dev/pkg/hack/generate-knative.sh \
+             vendor/knative.dev/eventing/hack/update-cert-manager.sh || true


### PR DESCRIPTION
Testing a possible solution for failures in https://github.com/openshift-knative/eventing-kafka-broker/pull/943

The user running tests in CI does not have permissions to chmod because he's not owner. This needs to be done earlier when building the image.

