### PR TITLE
[release-v1.12] Patch for chmod on codegen files

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -90,6 +90,5 @@ fi
 "${REPO_ROOT_DIR}"/hack/update-deps.sh
 
 cert_manager_installer="${REPO_ROOT_DIR}/vendor/knative.dev/eventing/hack/update-cert-manager.sh"
-chmod +x "${cert_manager_installer}" # Allow executing cert-manager script
-"${cert_manager_installer}"
-chmod -x "${cert_manager_installer}" # Revert execute permissions
+
+bash "${cert_manager_installer}"

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -55,8 +55,12 @@ metadata:
 EOF
 
   ./test/kafka/kafka_setup.sh || return $?
-  create_sasl_secrets || return $?
-  create_tls_secrets || return $?
+
+  ( # Do not leak sensitive information to logs.
+    set +x
+    create_sasl_secrets || return $?
+    create_tls_secrets || return $?
+  )
 
   KNATIVE_EVENTING_KAFKA_BROKER_MANIFESTS_DIR="$(pwd)/openshift/release/artifacts"
   export KNATIVE_EVENTING_KAFKA_BROKER_MANIFESTS_DIR

--- a/openshift/patches/chmod-codegen.patch
+++ b/openshift/patches/chmod-codegen.patch
@@ -1,0 +1,12 @@
+diff --git a/vendor/knative.dev/hack/codegen-library.sh b/vendor/knative.dev/hack/codegen-library.sh
+index d9cf1ce7e..0f21d457e 100644
+--- a/vendor/knative.dev/hack/codegen-library.sh
++++ b/vendor/knative.dev/hack/codegen-library.sh
+@@ -31,5 +31,5 @@ export GOBIN=${GOPATH}/bin # Set GOBIN explicitly as deepcopy-gen is installed b
+ export CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
+ export KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/knative.dev/pkg 2>/dev/null || echo "${REPO_ROOT_DIR}")}
+ 
+-chmod +x ${CODEGEN_PKG}/generate-groups.sh
+-chmod +x ${KNATIVE_CODEGEN_PKG}/hack/generate-knative.sh
++[ -x ${CODEGEN_PKG}/generate-groups.sh ] || chmod +x ${CODEGEN_PKG}/generate-groups.sh
++[ -x ${KNATIVE_CODEGEN_PKG}/hack/generate-knative.sh ] || chmod +x ${KNATIVE_CODEGEN_PKG}/hack/generate-knative.sh

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 source $(dirname $0)/resolve.sh
 
 GITHUB_ACTIONS=true $(dirname $0)/../../hack/update-codegen.sh
+git apply openshift/patches/chmod-codegen.patch
 
 # Eventing core will bring the config tracing ConfigMap, so remove it from heret
 rm -f control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml

--- a/vendor/knative.dev/hack/codegen-library.sh
+++ b/vendor/knative.dev/hack/codegen-library.sh
@@ -31,5 +31,5 @@ export GOBIN=${GOPATH}/bin # Set GOBIN explicitly as deepcopy-gen is installed b
 export CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 export KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/knative.dev/pkg 2>/dev/null || echo "${REPO_ROOT_DIR}")}
 
-chmod +x ${CODEGEN_PKG}/generate-groups.sh
-chmod +x ${KNATIVE_CODEGEN_PKG}/hack/generate-knative.sh
+[ -x ${CODEGEN_PKG}/generate-groups.sh ] || chmod +x ${CODEGEN_PKG}/generate-groups.sh
+[ -x ${KNATIVE_CODEGEN_PKG}/hack/generate-knative.sh ] || chmod +x ${KNATIVE_CODEGEN_PKG}/hack/generate-knative.sh


### PR DESCRIPTION
This is similar to [PR for release-v1.11](https://github.com/openshift-knative/eventing-kafka-broker/pull/884).
The required [upstream change](https://github.com/knative/hack/commit/d4af42e9b2225f807d75066f3b377c880646f003) was not backported to release-1.12 branch so we still need to have this downstream patch.

This fixes issues like this:
```
 make[1]: Entering directory `/go/src/github.com/openshift-knative/eventing-kafka-broker'
./openshift/release/generate-release.sh 
chmod: changing permissions of './vendor/k8s.io/code-generator/generate-groups.sh': Operation not permitted 
```

This change also includes calling update_cert_manager.sh via bash directly, another backport from upstream.
