### PR TITLE
Cert injection, rely on workload's subPath injection 

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -227,7 +227,7 @@ public class ConsumerVerticleBuilder {
 
   private PemTrustOptions openshiftPemTrustOptions() {
     // TODO: Go for all files
-    return new PemTrustOptions().addCertPath("/ocp-serverless-custom-certs/ca-bundle.crt/ca-bundle.crt");
+    return new PemTrustOptions().addCertPath("/ocp-serverless-custom-certs/ca-bundle.crt");
   }
 
   private ResponseHandler createResponseHandler(final Vertx vertx) {

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -66,7 +66,7 @@ EOF
   export KNATIVE_EVENTING_KAFKA_BROKER_MANIFESTS_DIR
 
   local operator_dir=/tmp/serverless-operator
-  git clone --branch main https://github.com/openshift-knative/serverless-operator.git $operator_dir
+  git clone --branch use_subPath_on_mounts https://github.com/matzew/serverless-operator.git $operator_dir
   export GOPATH=/tmp/go
   local failed=0
   pushd $operator_dir || return $?


### PR DESCRIPTION
/hold

THIS IS ONLY A TEST

It does test the combination of both patches, that are required:

* https://github.com/openshift-knative/eventing-kafka-broker/pull/931  (_this_ PR was created out of _that_ 931 PR)
* https://github.com/openshift-knative/serverless-operator/pull/2422 (_this_ PR is using the branch of _that_ 2422 PR) 


DO NOT MERGE _THIS_ PR.

Let's merge the two other PRs