### PR TITLE
[release-v1.10] Updating logback-core to latest 1.12.x

### DIFF
--- a/data-plane/THIRD-PARTY.txt
+++ b/data-plane/THIRD-PARTY.txt
@@ -1,7 +1,7 @@
 
 Lists of 216 third-party dependencies.
-     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Classic Module (ch.qos.logback:logback-classic:1.2.11 - http://logback.qos.ch/logback-classic)
-     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Core Module (ch.qos.logback:logback-core:1.2.11 - http://logback.qos.ch/logback-core)
+     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Classic Module (ch.qos.logback:logback-classic:1.2.13 - http://logback.qos.ch/logback-classic)
+     (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Core Module (ch.qos.logback:logback-core:1.2.13 - http://logback.qos.ch/logback-core)
      (Apache License 2.0) brotli4j (com.aayushatharva.brotli4j:brotli4j:1.8.0 - https://github.com/hyperxpro/Brotli4j/brotli4j)
      (Apache License 2.0) native-linux-x86_64 (com.aayushatharva.brotli4j:native-linux-x86_64:1.8.0 - https://github.com/hyperxpro/Brotli4j/natives/native-linux-x86_64)
      (The Apache Software License, Version 2.0) Jackson-annotations (com.fasterxml.jackson.core:jackson-annotations:2.13.4 - http://github.com/FasterXML/jackson)
@@ -214,5 +214,5 @@ Lists of 216 third-party dependencies.
      (MIT License) SLF4J API Module (org.slf4j:slf4j-api:1.7.36 - http://www.slf4j.org)
      (MIT License) SLF4J NOP Binding (org.slf4j:slf4j-nop:1.7.36 - http://www.slf4j.org)
      (Apache License 2.0) wildfly-common (org.wildfly.common:wildfly-common:1.5.4.Final-format-001 - http://www.jboss.org/wildfly-common)
-     (Apache-2.0) snappy-java (org.xerial.snappy:snappy-java:1.1.8.4 - https://github.com/xerial/snappy-java)
+     (Apache-2.0) snappy-java (org.xerial.snappy:snappy-java:1.1.10.5 - https://github.com/xerial/snappy-java)
      (Apache License, Version 2.0) SnakeYAML (org.yaml:snakeyaml:1.33 - https://bitbucket.org/snakeyaml/snakeyaml)

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -50,7 +50,7 @@
     <protobuf.version>3.20.3</protobuf.version>
     <bucket4j.version>7.4.0</bucket4j.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <ch.qos.logback.version>1.2.11</ch.qos.logback.version>
+    <ch.qos.logback.version>1.2.13</ch.qos.logback.version>
     <net.logstash.logback.encoder.version>7.2</net.logstash.logback.encoder.version>
     <assertj.version>3.22.0</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>


### PR DESCRIPTION
same like #938, but for `release-v1.10` branch