### PR TITLE
[release-v1.11] Rename config-kafka-features feature flags to be consistent with eventing core feature flag names (#3512)

### DIFF
--- a/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml
+++ b/control-plane/config/eventing-kafka-broker/200-controller/100-config-kafka-features.yaml
@@ -4,7 +4,7 @@ metadata:
   name: config-kafka-features
   namespace: knative-eventing
   annotations:
-    knative.dev/example-checksum: "1192895d"
+    knative.dev/example-checksum: "cf3393de"
 data:
   _example: |-
     ################################
@@ -24,27 +24,27 @@ data:
     # Controls whether the dispatcher should use the rate limiter based on the number of virtual replicas.
     # 1. Enabled: The rate limiter is applied.
     # 2. Disabled: The rate limiter is not applied.
-    dispatcher.rate-limiter: "disabled"
+    dispatcher-rate-limiter: "disabled"
     # Controls whether the dispatcher should record additional metrics.
     # 1. Enabled: The metrics are recorded.
     # 2. Disabled: The metrics are not recorded.
-    dispatcher.ordered-executor-metrics: "disabled"
+    dispatcher-ordered-executor-metrics: "disabled"
     # Controls whether the controller should autoscale consumer resources with KEDA
     # 1. Enabled: KEDA autoscaling of consumers will be setup.
     # 2. Disabled: KEDA autoscaling of consumers will not be setup.
-    controller.autoscaler: "disabled"
+    controller-autoscaler-keda: "disabled"
     # The Go text/template used to generate consumergroup ID for triggers.
     # The template can reference the trigger Kubernetes metadata only.
-    triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+    triggers-consumergroup-template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
     # The Go text/template used to generate topics for Brokers.
     # The template can reference the broker Kubernetes metadata only.
-    brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+    brokers-topic-template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
     # The Go text/template used to generate topics for Channels.
     # The template can reference the channel Kubernetes metadata only.
-    channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"
-  dispatcher.rate-limiter: "disabled"
-  dispatcher.ordered-executor-metrics: "disabled"
-  controller.autoscaler: "disabled"
-  triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
-  brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
-  channels.topic.template: "knative-messaging-kafka.{{ .Namespace }}.{{ .Name }}"
+    channels-topic-template: "knative-channel-{{ .Namespace }}-{{ .Name }}"
+  dispatcher-rate-limiter: "disabled"
+  dispatcher-ordered-executor-metrics: "disabled"
+  controller-autoscaler-keda: "disabled"
+  triggers-consumergroup-template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+  brokers-topic-template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+  channels-topic-template: "knative-messaging-kafka.{{ .Namespace }}.{{ .Name }}"

--- a/control-plane/pkg/apis/config/features.go
+++ b/control-plane/pkg/apis/config/features.go
@@ -80,11 +80,17 @@ func NewFeaturesConfigFromMap(cm *corev1.ConfigMap) (*KafkaFeatureFlags, error) 
 	nc := DefaultFeaturesConfig()
 	err := configmap.Parse(cm.Data,
 		asFlag("dispatcher.rate-limiter", &nc.features.DispatcherRateLimiter),
+		asFlag("dispatcher-rate-limiter", &nc.features.DispatcherRateLimiter),
 		asFlag("dispatcher.ordered-executor-metrics", &nc.features.DispatcherOrderedExecutorMetrics),
+		asFlag("dispatcher-ordered-executor-metrics", &nc.features.DispatcherOrderedExecutorMetrics),
 		asFlag("controller.autoscaler", &nc.features.ControllerAutoscaler),
+		asFlag("controller-autoscaler-keda", &nc.features.ControllerAutoscaler),
 		asTemplate("triggers.consumergroup.template", &nc.features.TriggersConsumerGroupTemplate),
+		asTemplate("triggers-consumergroup-template", &nc.features.TriggersConsumerGroupTemplate),
 		asTemplate("brokers.topic.template", &nc.features.BrokersTopicTemplate),
+		asTemplate("brokers-topic-template", &nc.features.BrokersTopicTemplate),
 		asTemplate("channels.topic.template", &nc.features.ChannelsTopicTemplate),
+		asTemplate("channels-topic-template", &nc.features.ChannelsTopicTemplate),
 	)
 	return nc, err
 }

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,7 +1,7 @@
 # DO NOT EDIT! Generated Dockerfile.
 
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 RUN echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "name=Kubernetes" >> /etc/yum.repos.d/kubernetes.repo && \

--- a/openshift/ci-operator/knative-images/event_display/Dockerfile
+++ b/openshift/ci-operator/knative-images/event_display/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/cmd/event_display.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-images/heartbeats/Dockerfile
+++ b/openshift/ci-operator/knative-images/heartbeats/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/cmd/heartbeats.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-images/kafka-controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/kafka-controller/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for control-plane/cmd/kafka-controller.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-images/kafka-source-controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/kafka-source-controller/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for control-plane/cmd/kafka-source-controller.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-images/migrate/Dockerfile
+++ b/openshift/ci-operator/knative-images/migrate/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-images/post-install/Dockerfile
+++ b/openshift/ci-operator/knative-images/post-install/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for control-plane/cmd/post-install.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-images/webhook-kafka/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook-kafka/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for control-plane/cmd/webhook-kafka.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/committed-offset/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/committed-offset/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for test/test_images/committed-offset.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/consumer-group-lag-provider-test/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/consumer-group-lag-provider-test/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for test/test_images/consumer-group-lag-provider-test.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/event-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/event-sender/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/event-sender.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/eventshub/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/eventshub/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/reconciler-test/cmd/eventshub.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/kafka-consumer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/kafka-consumer/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for test/test_images/kafka-consumer.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/logs-exporter/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/logs-exporter/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for test/cmd/logs-exporter.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/performance/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/performance/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/performance.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/print/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/print/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/print.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/recordevents/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/recordevents/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/recordevents.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/request-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/request-sender/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/request-sender.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/watch-cm/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/watch-cm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for test/cmd/watch-cm.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/wathola-fetcher/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-fetcher/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/wathola-fetcher.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/wathola-forwarder/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-forwarder/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/wathola-forwarder.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/wathola-receiver/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-receiver/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/wathola-receiver.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/wathola-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-sender/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/wathola-sender.
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/source-image/Dockerfile
+++ b/openshift/ci-operator/source-image/Dockerfile
@@ -2,4 +2,6 @@
 
 FROM src
 
-RUN chmod +x vendor/k8s.io/code-generator/generate-groups.sh vendor/knative.dev/pkg/hack/generate-knative.sh || true
+RUN chmod +x vendor/k8s.io/code-generator/generate-groups.sh || true
+RUN chmod +x vendor/knative.dev/pkg/hack/generate-knative.sh || true
+RUN chmod +x vendor/k8s.io/code-generator/generate-internal-groups.sh || true

--- a/openshift/release/artifacts/eventing-kafka-controller.yaml
+++ b/openshift/release/artifacts/eventing-kafka-controller.yaml
@@ -1279,7 +1279,7 @@ metadata:
   name: config-kafka-features
   namespace: knative-eventing
   annotations:
-    knative.dev/example-checksum: "1192895d"
+    knative.dev/example-checksum: "cf3393de"
 data:
   _example: |-
     ################################
@@ -1299,30 +1299,30 @@ data:
     # Controls whether the dispatcher should use the rate limiter based on the number of virtual replicas.
     # 1. Enabled: The rate limiter is applied.
     # 2. Disabled: The rate limiter is not applied.
-    dispatcher.rate-limiter: "disabled"
+    dispatcher-rate-limiter: "disabled"
     # Controls whether the dispatcher should record additional metrics.
     # 1. Enabled: The metrics are recorded.
     # 2. Disabled: The metrics are not recorded.
-    dispatcher.ordered-executor-metrics: "disabled"
+    dispatcher-ordered-executor-metrics: "disabled"
     # Controls whether the controller should autoscale consumer resources with KEDA
     # 1. Enabled: KEDA autoscaling of consumers will be setup.
     # 2. Disabled: KEDA autoscaling of consumers will not be setup.
-    controller.autoscaler: "disabled"
+    controller-autoscaler-keda: "disabled"
     # The Go text/template used to generate consumergroup ID for triggers.
     # The template can reference the trigger Kubernetes metadata only.
-    triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+    triggers-consumergroup-template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
     # The Go text/template used to generate topics for Brokers.
     # The template can reference the broker Kubernetes metadata only.
-    brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+    brokers-topic-template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
     # The Go text/template used to generate topics for Channels.
     # The template can reference the channel Kubernetes metadata only.
-    channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"
-  dispatcher.rate-limiter: "disabled"
-  dispatcher.ordered-executor-metrics: "disabled"
-  controller.autoscaler: "disabled"
-  triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
-  brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
-  channels.topic.template: "knative-messaging-kafka.{{ .Namespace }}.{{ .Name }}"
+    channels-topic-template: "knative-channel-{{ .Namespace }}-{{ .Name }}"
+  dispatcher-rate-limiter: "disabled"
+  dispatcher-ordered-executor-metrics: "disabled"
+  controller-autoscaler-keda: "disabled"
+  triggers-consumergroup-template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+  brokers-topic-template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+  channels-topic-template: "knative-messaging-kafka.{{ .Namespace }}.{{ .Name }}"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/openshift/release/artifacts/eventing-kafka.yaml
+++ b/openshift/release/artifacts/eventing-kafka.yaml
@@ -1279,7 +1279,7 @@ metadata:
   name: config-kafka-features
   namespace: knative-eventing
   annotations:
-    knative.dev/example-checksum: "1192895d"
+    knative.dev/example-checksum: "cf3393de"
 data:
   _example: |-
     ################################
@@ -1299,30 +1299,30 @@ data:
     # Controls whether the dispatcher should use the rate limiter based on the number of virtual replicas.
     # 1. Enabled: The rate limiter is applied.
     # 2. Disabled: The rate limiter is not applied.
-    dispatcher.rate-limiter: "disabled"
+    dispatcher-rate-limiter: "disabled"
     # Controls whether the dispatcher should record additional metrics.
     # 1. Enabled: The metrics are recorded.
     # 2. Disabled: The metrics are not recorded.
-    dispatcher.ordered-executor-metrics: "disabled"
+    dispatcher-ordered-executor-metrics: "disabled"
     # Controls whether the controller should autoscale consumer resources with KEDA
     # 1. Enabled: KEDA autoscaling of consumers will be setup.
     # 2. Disabled: KEDA autoscaling of consumers will not be setup.
-    controller.autoscaler: "disabled"
+    controller-autoscaler-keda: "disabled"
     # The Go text/template used to generate consumergroup ID for triggers.
     # The template can reference the trigger Kubernetes metadata only.
-    triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+    triggers-consumergroup-template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
     # The Go text/template used to generate topics for Brokers.
     # The template can reference the broker Kubernetes metadata only.
-    brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+    brokers-topic-template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
     # The Go text/template used to generate topics for Channels.
     # The template can reference the channel Kubernetes metadata only.
-    channels.topic.template: "knative-channel-{{ .Namespace }}-{{ .Name }}"
-  dispatcher.rate-limiter: "disabled"
-  dispatcher.ordered-executor-metrics: "disabled"
-  controller.autoscaler: "disabled"
-  triggers.consumergroup.template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
-  brokers.topic.template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
-  channels.topic.template: "knative-messaging-kafka.{{ .Namespace }}.{{ .Name }}"
+    channels-topic-template: "knative-channel-{{ .Namespace }}-{{ .Name }}"
+  dispatcher-rate-limiter: "disabled"
+  dispatcher-ordered-executor-metrics: "disabled"
+  controller-autoscaler-keda: "disabled"
+  triggers-consumergroup-template: "knative-trigger-{{ .Namespace }}-{{ .Name }}"
+  brokers-topic-template: "knative-broker-{{ .Namespace }}-{{ .Name }}"
+  channels-topic-template: "knative-messaging-kafka.{{ .Namespace }}.{{ .Name }}"
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
Backport of https://github.com/knative-extensions/eventing-kafka-broker/commit/930a91b33e5c22b62b7affb5d9cb2301a7f4e078