### PR TITLE
[release-v1.11] Backport fix for random consumer group id access

### DIFF
--- a/control-plane/pkg/kafka/testing/admin_mock.go
+++ b/control-plane/pkg/kafka/testing/admin_mock.go
@@ -173,7 +173,7 @@ func (m *MockKafkaClusterAdmin) DescribeConsumerGroups(groups []string) ([]*sara
 		m.T.Errorf("unexpected consumer groups %v, expected %v", groups, m.ExpectedConsumerGroups)
 	}
 
-	return m.ExpectedGroupDescriptionOnDescribeConsumerGroups, m.ExpectedErrorOnDescribeTopics
+	return m.ExpectedGroupDescriptionOnDescribeConsumerGroups, m.ExpectedErrorOnDescribeConsumerGroups
 }
 
 func (m *MockKafkaClusterAdmin) ListConsumerGroupOffsets(group string, topicPartitions map[string][]int32) (*sarama.OffsetFetchResponse, error) {

--- a/control-plane/pkg/reconciler/trigger/trigger.go
+++ b/control-plane/pkg/reconciler/trigger/trigger.go
@@ -18,10 +18,12 @@ package trigger
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
 
+	"github.com/Shopify/sarama"
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -438,14 +440,13 @@ func (r *Reconciler) reconcileConsumerGroup(ctx context.Context, broker *eventin
 	if !ok {
 		// Check if a consumer group exists with the old naming convention
 		groupID = string(trigger.UID)
-
 		valid, err := kafka.AreConsumerGroupsPresentAndValid(kafkaClusterAdmin, groupID)
-		if err != nil {
-			return false, fmt.Errorf("unable to query for existing consumergroup: %w", err)
+		if err != nil && !isGroupAuthorizationError(err) {
+			return false, fmt.Errorf("unable to query for existing consumergroup %q: %w", groupID, err)
 		}
 
 		// No existing consumer groups, use new naming
-		if !valid {
+		if !valid || isGroupAuthorizationError(err) {
 			groupID, err = r.KafkaFeatureFlags.ExecuteTriggersConsumerGroupTemplate(trigger.ObjectMeta)
 			if err != nil {
 				return false, fmt.Errorf("couldn't generate new consumergroup id: %w", err)
@@ -487,4 +488,9 @@ func deliveryOrderFromString(val string) (contract.DeliveryOrder, error) {
 	default:
 		return contract.DeliveryOrder_UNORDERED, fmt.Errorf("invalid annotation %s value: %s. Allowed values [ %q | %q ]", deliveryOrderAnnotation, val, sources.Ordered, sources.Unordered)
 	}
+}
+
+func isGroupAuthorizationError(err error) bool {
+	return errors.Is(err, sarama.ErrGroupAuthorizationFailed) ||
+		errors.Is(err, sarama.ErrClusterAuthorizationFailed)
 }

--- a/control-plane/pkg/reconciler/trigger/trigger_test.go
+++ b/control-plane/pkg/reconciler/trigger/trigger_test.go
@@ -39,6 +39,7 @@ import (
 	"knative.dev/pkg/resolver"
 	"knative.dev/pkg/tracker"
 
+	apisconfig "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/config"
 	sources "knative.dev/eventing-kafka-broker/control-plane/pkg/apis/sources/v1beta1"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1"
@@ -88,6 +89,9 @@ var (
 	exponential = eventingduck.BackoffPolicyExponential
 
 	bootstrapServers = "kafka-1:9092,kafka-2:9093"
+
+	expectedErrorOnDescribeConsumerGroupsKey = "expectedErrorOnDescribeConsumerGroupsKey"
+	featureFlagsKey                          = "featureFlagsKey"
 )
 
 type EgressBuilder struct {
@@ -197,6 +201,150 @@ func triggerReconciliation(t *testing.T, format string, env config.Env, useNewFi
 						reconcilertesting.WithTriggerDeadLetterSinkNotConfigured(),
 					),
 				},
+			},
+		},
+		{
+			Name: "Reconciled normal - preserve status group.id annotation",
+			Objects: []runtime.Object{
+				NewBroker(
+					BrokerReady,
+					WithTopicStatusAnnotation(BrokerTopic()),
+					WithBootstrapServerStatusAnnotation(bootstrapServers),
+				),
+				newTrigger(
+					withTriggerStatusGroupIdAnnotation("aaa"),
+				),
+				NewService(),
+				NewConfigMapFromContract(&contract.Contract{
+					Resources: []*contract.Resource{
+						{
+							Uid:     BrokerUUID,
+							Topics:  []string{BrokerTopic()},
+							Ingress: &contract.Ingress{Path: receiver.Path(BrokerNamespace, BrokerName)},
+						},
+					},
+				}, env.DataPlaneConfigMapNamespace, env.ContractConfigMapName, env.ContractConfigMapFormat),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
+				DataPlaneConfigMap(env.DataPlaneConfigMapNamespace, env.DataPlaneConfigConfigMapName, brokerreconciler.ConsumerConfigKey,
+					DataPlaneConfigInitialOffset(brokerreconciler.ConsumerConfigKey, sources.OffsetLatest),
+				),
+			},
+			Key: testKey,
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapUpdate(env.DataPlaneConfigMapNamespace, env.ContractConfigMapName, env.ContractConfigMapFormat, &contract.Contract{
+					Resources: []*contract.Resource{
+						{
+							Uid:     BrokerUUID,
+							Topics:  []string{BrokerTopic()},
+							Ingress: &contract.Ingress{Path: receiver.Path(BrokerNamespace, BrokerName)},
+							Egresses: []*contract.Egress{
+								{
+									Destination:   ServiceURL,
+									ConsumerGroup: "aaa",
+									Uid:           TriggerUUID,
+									Reference:     TriggerReference(),
+								},
+							},
+						},
+					},
+					Generation: 1,
+				}),
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
+					base.VolumeGenerationAnnotationKey: "1",
+				}),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: newTrigger(
+						reconcilertesting.WithInitTriggerConditions,
+						reconcilertesting.WithTriggerSubscribed(),
+						withSubscriberURI,
+						reconcilertesting.WithTriggerDependencyReady(),
+						reconcilertesting.WithTriggerBrokerReady(),
+						withTriggerSubscriberResolvedSucceeded(contract.DeliveryOrder_UNORDERED),
+						withTriggerStatusGroupIdAnnotation("aaa"),
+						reconcilertesting.WithTriggerDeadLetterSinkNotConfigured(),
+					),
+				},
+			},
+		},
+		{
+			Name: "Reconciled normal - preserve unauthorized to access uid-based group",
+			Objects: []runtime.Object{
+				NewBroker(
+					BrokerReady,
+					WithTopicStatusAnnotation(BrokerTopic()),
+					WithBootstrapServerStatusAnnotation(bootstrapServers),
+				),
+				newTrigger(),
+				NewService(),
+				NewConfigMapFromContract(&contract.Contract{
+					Resources: []*contract.Resource{
+						{
+							Uid:     BrokerUUID,
+							Topics:  []string{BrokerTopic()},
+							Ingress: &contract.Ingress{Path: receiver.Path(BrokerNamespace, BrokerName)},
+						},
+					},
+				}, env.DataPlaneConfigMapNamespace, env.ContractConfigMapName, env.ContractConfigMapFormat),
+				BrokerDispatcherPod(env.SystemNamespace, nil),
+				DataPlaneConfigMap(env.DataPlaneConfigMapNamespace, env.DataPlaneConfigConfigMapName, brokerreconciler.ConsumerConfigKey,
+					DataPlaneConfigInitialOffset(brokerreconciler.ConsumerConfigKey, sources.OffsetLatest),
+				),
+			},
+			Key: testKey,
+			WantEvents: []string{
+				finalizerUpdatedEvent,
+			},
+			WantPatches: []clientgotesting.PatchActionImpl{
+				patchFinalizers(),
+			},
+			WantUpdates: []clientgotesting.UpdateActionImpl{
+				ConfigMapUpdate(env.DataPlaneConfigMapNamespace, env.ContractConfigMapName, env.ContractConfigMapFormat, &contract.Contract{
+					Resources: []*contract.Resource{
+						{
+							Uid:     BrokerUUID,
+							Topics:  []string{BrokerTopic()},
+							Ingress: &contract.Ingress{Path: receiver.Path(BrokerNamespace, BrokerName)},
+							Egresses: []*contract.Egress{
+								{
+									Destination:   ServiceURL,
+									ConsumerGroup: fmt.Sprintf("knative-trigger-%s-%s", TriggerNamespace, TriggerName),
+									Uid:           TriggerUUID,
+									Reference:     TriggerReference(),
+								},
+							},
+						},
+					},
+					Generation: 1,
+				}),
+				BrokerDispatcherPodUpdate(env.SystemNamespace, map[string]string{
+					base.VolumeGenerationAnnotationKey: "1",
+				}),
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
+				{
+					Object: newTrigger(
+						reconcilertesting.WithInitTriggerConditions,
+						reconcilertesting.WithTriggerSubscribed(),
+						withSubscriberURI,
+						reconcilertesting.WithTriggerDependencyReady(),
+						reconcilertesting.WithTriggerBrokerReady(),
+						withTriggerSubscriberResolvedSucceeded(contract.DeliveryOrder_UNORDERED),
+						withTriggerStatusGroupIdAnnotation(fmt.Sprintf("knative-trigger-%s-%s", TriggerNamespace, TriggerName)),
+						reconcilertesting.WithTriggerDeadLetterSinkNotConfigured(),
+					),
+				},
+			},
+			OtherTestData: map[string]interface{}{
+				expectedErrorOnDescribeConsumerGroupsKey: fmt.Errorf("error: %w", sarama.ErrGroupAuthorizationFailed),
+				featureFlagsKey:                          apisconfig.DefaultFeaturesConfig(),
 			},
 		},
 		{
@@ -2949,6 +3097,9 @@ func useTableWithFlags(t *testing.T, table TableTest, env *config.Env, flags fea
 
 		logger := logging.FromContext(ctx)
 
+		expectedErrorOnDescribeConsumerGroups, _ := row.OtherTestData[expectedErrorOnDescribeConsumerGroupsKey].(error)
+		featureFlags, _ := row.OtherTestData[featureFlagsKey].(*apisconfig.KafkaFeatureFlags)
+
 		reconciler := &Reconciler{
 			Reconciler: &base.Reconciler{
 				KubeClient:                   kubeclient.Get(ctx),
@@ -2972,6 +3123,7 @@ func useTableWithFlags(t *testing.T, table TableTest, env *config.Env, flags fea
 			Env:                       env,
 			BrokerClass:               kafka.BrokerClass,
 			DataPlaneConfigMapLabeler: base.NoopConfigmapOption,
+			KafkaFeatureFlags:         featureFlags,
 			InitOffsetsFunc: func(ctx context.Context, kafkaClient sarama.Client, kafkaAdminClient sarama.ClusterAdmin, topics []string, consumerGroup string) (int32, error) {
 				return 1, nil
 			},
@@ -2997,7 +3149,8 @@ func useTableWithFlags(t *testing.T, table TableTest, env *config.Env, flags fea
 							State:   "Stable",
 						},
 					},
-					T: t,
+					ExpectedErrorOnDescribeConsumerGroups: expectedErrorOnDescribeConsumerGroups,
+					T:                                     t,
 				}, nil
 			},
 		}


### PR DESCRIPTION
This is the non breaking change related to https://github.com/knative-extensions/eventing-kafka-broker/commit/bfeb3c39f741b8380788cd573bff499c59834e47