### PR TITLE
[release-v1.11] Use filtered global resync for triggers (#3678)

### DIFF
--- a/control-plane/pkg/reconciler/trigger/controller.go
+++ b/control-plane/pkg/reconciler/trigger/controller.go
@@ -118,7 +118,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher, configs *conf
 	})
 
 	globalResync := func(_ interface{}) {
-		impl.GlobalResync(triggerInformer.Informer())
+		impl.FilteredGlobalResync(filterTriggers(reconciler.BrokerLister, kafka.BrokerClass, FinalizerName), triggerInformer.Informer())
 	}
 
 	configmapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{


### PR DESCRIPTION
The current global resync accidently queues triggers that aren't associated with our brokers.