### PR TITLE
Add missing param to `resolve_resources` call

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -56,7 +56,7 @@ resolve_resources data-plane/config/channel-tls $eventing_kafka_tls_networking "
 resolve_resources data-plane/config/sink-tls $eventing_kafka_tls_networking "$image_prefix" "$tag"
 
 # Post-install jobs
-resolve_resources control-plane/config/post-install $eventing_kafka_post_install "$image_prefix"
+resolve_resources control-plane/config/post-install $eventing_kafka_post_install "$image_prefix" "$tag"
 
 # One file with everything
 cat $eventing_kafka_controller >> $eventing_kafka


### PR DESCRIPTION
Currently we have the following issue in our update-to-head Jenkins job:

```
01:44:45  Resolving data-plane/config/channel-tls/channel-ingress-tls-certificate.yaml
01:44:45  data-plane/config/sink-tls openshift/release/artifacts/eventing-kafka-tls-networking.yaml registry.ci.openshift.org/openshift/knative-eventing-kafka-broker knative-nightly
01:44:45  Writing resolved yaml to openshift/release/artifacts/eventing-kafka-tls-networking.yaml nightly
01:44:45  Resolving data-plane/config/sink-tls/sink-ingress-tls-certificate.yaml
01:44:45  control-plane/config/post-install openshift/release/artifacts/eventing-kafka-post-install.yaml registry.ci.openshift.org/openshift/knative-eventing-kafka-broker
01:44:45  ./openshift/release/resolve.sh: line 9: $4: unbound variable
01:44:45  make: *** [Makefile:77: generate-release] Error 1
```

e.g. in https://master-jenkins-csb-serverless-qe.apps.ocp-c1.prod.psi.redhat.com/job/ci/job/knative-nightly-ci-eventing-kafka-broker/612/console

This PR adds the missing parameter to the `resolve_resources` call