### PR TITLE
[release-v1.13] Backporting OCP Bundle injection code for kafka dataplane

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -213,7 +213,7 @@ public class ConsumerVerticleBuilder {
     }
 
     private WebClientOptions createWebClientOptionsFromCACerts(final String caCerts) {
-        final var pemTrustOptions = new PemTrustOptions();
+        final var pemTrustOptions = new PemTrustOptions(openshiftPemTrustOptions());
         for (String trustBundle : consumerVerticleContext.getTrustBundles()) {
             pemTrustOptions.addCertValue(Buffer.buffer(trustBundle));
         }
@@ -222,6 +222,11 @@ public class ConsumerVerticleBuilder {
         }
         return new WebClientOptions(consumerVerticleContext.getWebClientOptions()).setTrustOptions(pemTrustOptions);
     }
+
+  private PemTrustOptions openshiftPemTrustOptions() {
+    // TODO: Go for all files
+    return new PemTrustOptions().addCertPath("/ocp-serverless-custom-certs/ca-bundle.crt");
+  }
 
     private ResponseHandler createResponseHandler(final Vertx vertx) {
         if (consumerVerticleContext.getEgress().hasReplyUrl()) {


### PR DESCRIPTION
First introduced in 1.32/1.11

This contains the adjusted content of these two orignal commits:
* 9194e056c04a251cd8ef50e8355e03644d98e927
* e5f221fe0f8b756b54d1be1debd2be5d3ac5f4b0

Since than the code was changed for trust manager, hence the adjustments (similar to those for 1.11/1.32)