### PR TITLE
[release-v1.11] backport running new_tests with parallel 64

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -142,7 +142,7 @@ function run_e2e_new_tests() {
     ./test/scripts/first-event-delay.sh || return $?
   fi
 
-  common_opts=(--images.producer.file="${images_file}" --poll.timeout=8m)
+  common_opts=(--images.producer.file="${images_file}" --poll.timeout=8m -parallel 64)
 
   go_test_e2e -timeout=100m ./test/e2e_new/... "${common_opts[@]}" || return $?
   go_test_e2e -timeout=100m ./test/e2e_new_channel/... "${common_opts[@]}" || return $?


### PR DESCRIPTION
backport https://github.com/openshift-knative/eventing-kafka-broker/pull/1017