### PR TITLE
Enable eventtype-auto-create feature flag

### DIFF
--- a/openshift/knative-eventing.yaml
+++ b/openshift/knative-eventing.yaml
@@ -19,6 +19,7 @@ spec:
       kreference-mapping: "disabled"
       strict-subscriber: "disabled"
       new-trigger-filters: "enabled"
+      eventtype-auto-create: "enabled"
     config-br-defaults:
       default-br-config: |
         clusterDefault:


### PR DESCRIPTION
The eventtype autocreate feature (and tests) were added in upstream in https://github.com/knative-extensions/eventing-kafka-broker/pull/3585.

So we should enable it for our tests as well.

Test run in release-next in #1027

Should also help with #1002

/hold
to wait for the test results in #1027