### PR TITLE
Update namespaced broker CA bundle patch

### DIFF
--- a/openshift/patches/namespaced_broker_copy_trustedca_cm.patch
+++ b/openshift/patches/namespaced_broker_copy_trustedca_cm.patch
@@ -1,10 +1,10 @@
 diff --git a/control-plane/pkg/reconciler/broker/namespaced_broker.go b/control-plane/pkg/reconciler/broker/namespaced_broker.go
-index 5e71fa6d0..4db94dede 100644
+index 759c13e94..c5a1fb07a 100644
 --- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
 +++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
-@@ -386,6 +386,7 @@ func (r *NamespacedReconciler) configMapsFromSystemNamespace(broker *eventing.Br
- 		"config-kafka-broker-data-plane",
+@@ -388,6 +388,7 @@ func (r *NamespacedReconciler) configMapsFromSystemNamespace(broker *eventing.Br
  		"config-tracing",
+ 		"config-features",
  		"kafka-config-logging",
 +		"config-openshift-trusted-cabundle",
  	}


### PR DESCRIPTION
As per title to fix Jenkins job:
https://master-jenkins-csb-serverless-qe.apps.ocp-c1.prod.psi.redhat.com/job/ci/job/knative-nightly-ci-eventing-kafka-broker/629/console

```
00:07:02.771  Checking patch control-plane/pkg/reconciler/broker/namespaced_broker.go...
00:07:02.771  error: while searching for:
00:07:02.771  		"config-kafka-broker-data-plane",
00:07:02.771  		"config-tracing",
00:07:02.771  		"kafka-config-logging",
00:07:02.771  	}
00:07:02.771  	resources := make([]unstructured.Unstructured, 0, len(configMaps))
00:07:02.771  	for _, name := range configMaps {
00:07:02.771  
00:07:02.771  error: patch failed: control-plane/pkg/reconciler/broker/namespaced_broker.go:386
00:07:02.771  error: control-plane/pkg/reconciler/broker/namespaced_broker.go: patch does not apply
```