### PR TITLE
[release-v1.12] Avoid possible nil pointer dereferences in consumergroup scheduling

### DIFF
--- a/control-plane/pkg/reconciler/consumergroup/controller.go
+++ b/control-plane/pkg/reconciler/consumergroup/controller.go
@@ -114,7 +114,7 @@ func NewController(ctx context.Context, watcher configmap.Watcher) *controller.I
 	}
 
 	r := &Reconciler{
-		SchedulerFunc:                      func(s string) Scheduler { return schedulers[strings.ToLower(s)] },
+		SchedulerFunc:                      func(s string) (Scheduler, bool) { sched, ok := schedulers[strings.ToLower(s)]; return sched, ok },
 		ConsumerLister:                     consumer.Get(ctx).Lister(),
 		InternalsClient:                    internalsclient.Get(ctx).InternalV1alpha1(),
 		SecretLister:                       secretinformer.Get(ctx).Lister(),


### PR DESCRIPTION
A manual backport of https://github.com/knative-extensions/eventing-kafka-broker/pull/3775

This is needed so that in the next release, we don't have the kafka controller CrashLoopBackoff from panics 