### PR TITLE
[release-v1.12] Remove usage of Vertx.currentContext()

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/AuthProvider.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/AuthProvider.java
@@ -18,6 +18,7 @@ package dev.knative.eventing.kafka.broker.core.security;
 import dev.knative.eventing.kafka.broker.contract.DataPlaneContract;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 
 /**
  * AuthProvider provides auth credentials.
@@ -25,8 +26,8 @@ import io.vertx.core.Future;
 @FunctionalInterface
 public interface AuthProvider {
 
-    static AuthProvider kubernetes() {
-        return new KubernetesAuthProvider(new DefaultKubernetesClient());
+    static AuthProvider kubernetes(final Vertx vertx) {
+        return new KubernetesAuthProvider(vertx, new DefaultKubernetesClient());
     }
 
     static AuthProvider noAuth() {

--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesAuthProvider.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/security/KubernetesAuthProvider.java
@@ -28,14 +28,16 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 
 class KubernetesAuthProvider implements AuthProvider {
 
+    private final Vertx vertx;
     private final KubernetesClient kubernetesClient;
 
-    KubernetesAuthProvider(final KubernetesClient client) {
+    KubernetesAuthProvider(final Vertx vertx, final KubernetesClient client) {
+        this.vertx = vertx;
         this.kubernetesClient = client;
     }
 
     private Future<Credentials> getCredentials(final DataPlaneContract.Reference secretReference) {
-        return Vertx.currentContext().executeBlocking(p -> {
+        return this.vertx.executeBlocking(p -> {
             try {
                 final Secret secret = getSecretFromKubernetes(secretReference);
                 final var credentials = new KubernetesCredentials(secret);
@@ -52,7 +54,7 @@ class KubernetesAuthProvider implements AuthProvider {
     }
 
     private Future<Credentials> getCredentials(final DataPlaneContract.MultiSecretReference secretReferences) {
-        return Vertx.currentContext().executeBlocking(p -> {
+        return this.vertx.executeBlocking(p -> {
             try {
                 final var credentials = new KubernetesCredentials(secretDataOf(secretReferences));
                 final var error = CredentialsValidator.validate(credentials);

--- a/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/KubernetesAuthProviderTest.java
+++ b/data-plane/core/src/test/java/dev/knative/eventing/kafka/broker/core/security/KubernetesAuthProviderTest.java
@@ -51,8 +51,8 @@ public class KubernetesAuthProviderTest {
     private static final String userPasswordSecretKey = "password";
 
     @BeforeEach
-    public void setUp() {
-        provider = new KubernetesAuthProvider(client);
+    public void setUp(final Vertx vertx) {
+        provider = new KubernetesAuthProvider(vertx, client);
     }
 
     @Test

--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/Main.java
@@ -113,7 +113,7 @@ public class Main {
                             consumerConfig,
                             webClientOptions,
                             producerConfig,
-                            AuthProvider.kubernetes(),
+                            AuthProvider.kubernetes(vertx),
                             Metrics.getRegistry(),
                             reactiveConsumerFactory,
                             reactiveProducerFactory),

--- a/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
+++ b/data-plane/receiver/src/main/java/dev/knative/eventing/kafka/broker/receiver/main/ReceiverVerticleFactory.java
@@ -69,7 +69,7 @@ class ReceiverVerticleFactory implements Supplier<Verticle> {
                 httpServerOptions,
                 httpsServerOptions,
                 v -> new IngressProducerReconcilableStore(
-                        AuthProvider.kubernetes(),
+                        AuthProvider.kubernetes(v),
                         producerConfigs,
                         properties -> kafkaProducerFactory.create(v, properties)),
                 this.ingressRequestHandler,


### PR DESCRIPTION
Fix errors like:

```
\"io.vertx.core.Vertx.currentContext()\" is null\n\tat dev.knative.eventing.kafka.broker.core.security.KubernetesAuthProvider.getCredentials(KubernetesAuthProvider.java:38)
```