### PR TITLE
[release-v1.12] reduce e2e_new tests parallelism to 20

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -144,7 +144,7 @@ function run_e2e_new_tests() {
     ./test/scripts/first-event-delay.sh || return $?
   fi
 
-  common_opts=(--images.producer.file="${images_file}" --poll.timeout=8m -parallel 64)
+  common_opts=(--images.producer.file="${images_file}" --poll.timeout=8m -parallel 20)
 
   go_test_e2e -timeout=100m ./test/e2e_new/... "${common_opts[@]}" || return $?
   go_test_e2e -timeout=100m ./test/e2e_new_channel/... "${common_opts[@]}" || return $?


### PR DESCRIPTION
Our current parallelization of 64 seems to be too much in CI, with significant client request throttling causing flakiness. Trying to reduce it to 20.