### PR TITLE
[release-v1.14] fix: only add triggerAuth to scaled objects when there is an actual value to reference (#3941)

### DIFF
--- a/control-plane/pkg/autoscaler/keda/keda.go
+++ b/control-plane/pkg/autoscaler/keda/keda.go
@@ -77,13 +77,14 @@ func GenerateScaleTriggers(cg *kafkainternals.ConsumerGroup, triggerAuthenticati
 		}
 
 		trigger := kedav1alpha1.ScaleTriggers{
-			Type:              "kafka",
-			Metadata:          triggerMetadata,
-			AuthenticationRef: &kedav1alpha1.ScaledObjectAuthRef{},
+			Type:     "kafka",
+			Metadata: triggerMetadata,
 		}
 
 		if triggerAuthentication != nil {
-			trigger.AuthenticationRef.Name = triggerAuthentication.Name
+			trigger.AuthenticationRef = &kedav1alpha1.ScaledObjectAuthRef{
+				Name: triggerAuthentication.Name,
+			}
 		}
 
 		triggers = append(triggers, trigger)

--- a/test/e2e_new/kafka_source_test.go
+++ b/test/e2e_new/kafka_source_test.go
@@ -242,6 +242,22 @@ func TestKafkaSourceKedaScaling(t *testing.T) {
 
 }
 
+func TestKafkaSourceScaledObject(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := global.Environment(
+		knative.WithKnativeNamespace(system.Namespace()),
+		knative.WithLoggingConfig,
+		knative.WithTracingConfig,
+		k8s.WithEventListener,
+		environment.WithPollTimings(5*time.Second, 4*time.Minute),
+		environment.Managed(t),
+	)
+
+	env.Test(ctx, t, features.KafkaSourceScaledObjectHasNoEmptyAuthRef())
+
+}
+
 func TestKafkaSourceTLSSink(t *testing.T) {
 
 	t.Parallel()


### PR DESCRIPTION
A backport of https://github.com/knative-extensions/eventing-kafka-broker/pull/3941 to fix errors on KEDA scaled objects when there is no need for an authentication reference