### PR TITLE
Switch to go install to install hack/generate

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
 
-GO111MODULE=off go get -u github.com/openshift-knative/hack/cmd/generate
+GO111MODULE=off go install github.com/openshift-knative/hack/cmd/generate
 
 $(go env GOPATH)/bin/generate \
   --root-dir "${repo_root_dir}" \

--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
 
+# make sure we install the latest version
+rm -f $(go env GOPATH)/bin/generate
 GO111MODULE=off go install github.com/openshift-knative/hack/cmd/generate
 
 $(go env GOPATH)/bin/generate \


### PR DESCRIPTION
> go get is no longer supported outside of a module in the legacy GOPATH mode (that is, with GO111MODULE=off). Other build commands, such as go build and go test, will continue to work indefinitely for legacy GOPATH programs.

from 1.22 release notes: https://tip.golang.org/doc/go1.22

Should fix https://master-jenkins-csb-serverless-qe.apps.ocp-c1.prod.psi.redhat.com/job/ci/job/knative-nightly-ci-eventing-kafka-broker/732/console