### PR TITLE
Use OCP 4.17 based image in generate to support Go 1.22

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -15,4 +15,5 @@ rm -rf "$tmp_dir"
 
 $(go env GOPATH)/bin/generate \
   --root-dir "${repo_root_dir}" \
-  --generators dockerfile
+  --generators dockerfile \
+  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17"


### PR DESCRIPTION
Same as openshift-knative/eventing/pull/657 but for EKB