### PR TITLE
[release-v1.14] fix: kafka controller does not panic on invalid kafka client config (#4002)

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_validation.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_validation.go
@@ -57,6 +57,9 @@ func (cts *ConsumerTemplateSpec) Validate(ctx context.Context) *apis.FieldError 
 		cts.Spec.Delivery.Validate(specCtx).ViaField("delivery"),
 		cts.Spec.Subscriber.Validate(specCtx).ViaField("subscriber"),
 	)
+	if cts.Spec.Configs.Configs == nil {
+		err = err.Also(apis.ErrMissingField("spec.configs"))
+	}
 	return err
 }
 

--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_validation_test.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_validation_test.go
@@ -109,6 +109,9 @@ func TestConsumerGroup_Validate(t *testing.T) {
 									Host:   "127.0.0.1",
 								},
 							},
+							Configs: ConsumerConfigs{
+								Configs: map[string]string{},
+							},
 						},
 					},
 				},
@@ -135,6 +138,9 @@ func TestConsumerGroup_Validate(t *testing.T) {
 									Name:       "my-seq",
 									APIVersion: "flows.knative.dev/v1",
 								},
+							},
+							Configs: ConsumerConfigs{
+								Configs: map[string]string{},
 							},
 						},
 					},
@@ -191,6 +197,9 @@ func TestConsumerGroup_Validate(t *testing.T) {
 									Host:   "127.0.0.1",
 								},
 							},
+							Configs: ConsumerConfigs{
+								Configs: map[string]string{},
+							},
 						},
 					},
 				},
@@ -214,6 +223,9 @@ func TestConsumerGroup_Validate(t *testing.T) {
 									Scheme: "http",
 									Host:   "127.0.0.1",
 								},
+							},
+							Configs: ConsumerConfigs{
+								Configs: map[string]string{},
 							},
 						},
 					},
@@ -243,6 +255,9 @@ func TestConsumerGroup_Validate(t *testing.T) {
 									Host:   "127.0.0.1",
 								},
 							},
+							Configs: ConsumerConfigs{
+								Configs: map[string]string{},
+							},
 						},
 					},
 				},
@@ -266,6 +281,9 @@ func TestConsumerGroup_Validate(t *testing.T) {
 									Scheme: "http",
 									Host:   "127.0.0.1",
 								},
+							},
+							Configs: ConsumerConfigs{
+								Configs: map[string]string{},
 							},
 						},
 					},

--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -301,10 +301,10 @@ func (r *Reconciler) deleteConsumerGroupMetadata(ctx context.Context, cg *kafkai
 	bootstrapServers := kafka.BootstrapServersArray(cg.Spec.Template.Spec.Configs.Configs["bootstrap.servers"])
 
 	kafkaClusterAdminClient, err := r.GetKafkaClusterAdmin(ctx, bootstrapServers, kafakSecret)
-	defer kafkaClusterAdminClient.Close()
 	if err != nil {
 		return fmt.Errorf("cannot obtain Kafka cluster admin, %w", err)
 	}
+	defer kafkaClusterAdminClient.Close()
 
 	groupId := cg.Spec.Template.Spec.Configs.Configs["group.id"]
 	if err = kafkaClusterAdminClient.DeleteConsumerGroup(groupId); err != nil && !errorIsOneOf(err, sarama.ErrUnknownTopicOrPartition, sarama.ErrGroupIDNotFound) {
@@ -596,10 +596,10 @@ func (r *Reconciler) reconcileInitialOffset(ctx context.Context, cg *kafkaintern
 	bootstrapServers := kafka.BootstrapServersArray(cg.Spec.Template.Spec.Configs.Configs["bootstrap.servers"])
 
 	kafkaClusterAdminClient, err := r.GetKafkaClusterAdmin(ctx, bootstrapServers, kafkaSecret)
-	defer kafkaClusterAdminClient.Close()
 	if err != nil {
 		return fmt.Errorf("cannot obtain Kafka cluster admin, %w", err)
 	}
+	defer kafkaClusterAdminClient.Close()
 
 	kafkaClient, err := r.GetKafkaClient(ctx, bootstrapServers, kafkaSecret)
 	if err != nil {


### PR DESCRIPTION
Cherry-pick of https://github.com/knative-extensions/eventing-kafka-broker/commit/12d1f32b144ed50ad4eea3f6ed00bac6128c2b05

* fix: kafka controller does not panic on invalid kafka client config
* fix: consumergroup configs are validated as non-nil
