### PR TITLE
[release-v1.14] fix: correct clusterrole permissions (#4016)

### DIFF
--- a/control-plane/config/post-install/200-controller-cluster-role.yaml
+++ b/control-plane/config/post-install/200-controller-cluster-role.yaml
@@ -28,6 +28,7 @@ rules:
       - "deployments"
     verbs:
       - "delete"
+      - "get"
       - "list"
   # we need to get statefulsets
   - apiGroups:


### PR DESCRIPTION
This is a backport of https://github.com/knative-extensions/eventing-kafka-broker/pull/4016 to make sure that the post install job has the correct permissions