### PR TITLE
[release-v1.14] update to golang 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/eventing-kafka-broker
 
-go 1.21
+go 1.22
 
 require (
 	github.com/IBM/sarama v1.43.2

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,7 +1,7 @@
 # DO NOT EDIT! Generated Dockerfile.
 
 # Dockerfile to bootstrap build and test in openshift-ci
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 RUN echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
     echo "name=Kubernetes" >> /etc/yum.repos.d/kubernetes.repo && \

--- a/openshift/ci-operator/knative-images/event_display/Dockerfile
+++ b/openshift/ci-operator/knative-images/event_display/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/cmd/event_display.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-images/heartbeats/Dockerfile
+++ b/openshift/ci-operator/knative-images/heartbeats/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/cmd/heartbeats.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-images/kafka-controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/kafka-controller/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for control-plane/cmd/kafka-controller.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-images/kafka-source-controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/kafka-source-controller/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for control-plane/cmd/kafka-source-controller.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-images/migrate/Dockerfile
+++ b/openshift/ci-operator/knative-images/migrate/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-images/post-install/Dockerfile
+++ b/openshift/ci-operator/knative-images/post-install/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for control-plane/cmd/post-install.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-images/webhook-kafka/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook-kafka/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for control-plane/cmd/webhook-kafka.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/committed-offset/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/committed-offset/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for test/test_images/committed-offset.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/consumer-group-lag-provider-test/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/consumer-group-lag-provider-test/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for test/test_images/consumer-group-lag-provider-test.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/event-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/event-sender/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/event-sender.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/eventshub/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/eventshub/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/reconciler-test/cmd/eventshub.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/kafka-consumer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/kafka-consumer/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for test/test_images/kafka-consumer.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/logs-exporter/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/logs-exporter/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for test/cmd/logs-exporter.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/performance/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/performance/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/performance.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/print/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/print/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/print.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/recordevents/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/recordevents/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/recordevents.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/request-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/request-sender/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/request-sender.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/watch-cm/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/watch-cm/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for test/cmd/watch-cm.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/wathola-fetcher/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-fetcher/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/wathola-fetcher.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/wathola-forwarder/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-forwarder/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/wathola-forwarder.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/wathola-receiver/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-receiver/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/wathola-receiver.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-test-images/wathola-sender/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wathola-sender/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT EDIT! Generated Dockerfile for vendor/knative.dev/eventing/test/test_images/wathola-sender.
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 as builder
 
 COPY . .
 

--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 
 repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
 
-GO111MODULE=off go get -u github.com/openshift-knative/hack/cmd/generate
+hack_tmp_dir=$(mktemp -d)
+git clone --branch main https://github.com/openshift-knative/hack "$hack_tmp_dir"
+pushd "$hack_tmp_dir" || return $?
+go install github.com/openshift-knative/hack/cmd/generate
+popd || return $?
+rm -rf "$hack_tmp_dir"
 
 $(go env GOPATH)/bin/generate \
   --root-dir "${repo_root_dir}" \


### PR DESCRIPTION
Not really sure what I am doing, but IIUC, SO 1.34 will use go 1.22, so we need to update eventing 1.14 to go 1.22

(as that's currently failing https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-knative-eventing-kafka-broker-release-v1.14-412-test-e2e-aws-412-c/1820646135702753280 

 ./hack/update-deps.sh
invalid value "1.22" for flag -compat: maximum supported Go version is 1.21.11 
)

