### PR TITLE
Run e2e tests in bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,15 @@ test-install:
 .PHONY: test-install
 
 test-e2e:
-	sh openshift/e2e-tests.sh
+	openshift/e2e-tests.sh
 .PHONY: test-e2e
 
 test-conformance:
-	sh openshift/e2e-conformance-tests.sh
+	openshift/e2e-conformance-tests.sh
 .PHONY: test-conformance
 
 test-reconciler:
-	sh openshift/e2e-rekt-tests.sh
+	openshift/e2e-rekt-tests.sh
 .PHONY: test-reconciler
 
 test-reconciler-keda:
@@ -44,7 +44,7 @@ test-reconciler-keda:
 .PHONY: test-reconciler-keda
 
 test-reconciler-encryption-auth:
-	sh openshift/e2e-rekt-encryption-auth-tests.sh
+	openshift/e2e-rekt-encryption-auth-tests.sh
 .PHONY: test-reconciler
 
 # Requires ko 0.2.0 or newer.


### PR DESCRIPTION
In #1132 we see 
```
sh openshift/e2e-rekt-tests.sh
/go/src/github.com/openshift-knative/eventing-kafka-broker/test/../vendor/knative.dev/hack/library.sh: line 184: `log.step': not a valid identifier
make: *** [Makefile:39: test-reconciler] Error 2
```
This is, as `log.step` is not a valid identifier in shell. Change came in via https://github.com/knative-extensions/eventing-kafka-broker/pull/4078/files#diff-f7fc5bff7eaf66c1c00c00e72e6e16a2b93ec32f0cbd1f6e9da25866cf7f73b0.

So removing the invocation via `sh` and let the script decide which shell to use (most use `#!/usr/bin/env bash`)

Testrun in #1253