### PR TITLE
[release-v1.14] Set the `name` value for metrics tags to the correct top-level resource

### DIFF
--- a/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_types.go
+++ b/control-plane/pkg/apis/internals/kafka/eventing/v1alpha1/consumer_group_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -108,6 +109,10 @@ type ConsumerGroupSpec struct {
 	// OIDCServiceAccountName is the name of service account used for this components
 	// OIDC authentication.
 	OIDCServiceAccountName *string `json:"oidcServiceAccountName,omitempty"`
+
+	// TopLevelResourceRef is a reference to a top level resource.
+	// For a ConsumerGroup associated with a Trigger, a Broker reference will be set.
+	TopLevelResourceRef *corev1.ObjectReference `json:"topLevelResourceRef,omitempty"`
 }
 
 type ConsumerGroupStatus struct {
@@ -208,6 +213,13 @@ func (cg *ConsumerGroup) GetUserFacingResourceRef() *metav1.OwnerReference {
 		}
 	}
 	return nil
+}
+
+// GetTopLevelUserFacingResourceRef gets the top level resource reference to the user-facing resources
+// that are backed by this ConsumerGroup using the OwnerReference list.
+// For example, for a Trigger, it will return a Broker reference.
+func (cg *ConsumerGroup) GetTopLevelUserFacingResourceRef() *corev1.ObjectReference {
+	return cg.Spec.TopLevelResourceRef
 }
 
 func (cg *ConsumerGroup) IsNotScheduled() bool {

--- a/control-plane/pkg/reconciler/consumer/consumer.go
+++ b/control-plane/pkg/reconciler/consumer/consumer.go
@@ -131,6 +131,14 @@ func (r *Reconciler) reconcileContractResource(ctx context.Context, c *kafkainte
 		egress.VReplicas = 1
 	}
 
+	topLevelUserFacingResourceRef, err := r.reconcileTopLevelUserFacingResourceRef(c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reconcile top-level user facing resource reference: %w", err)
+	}
+	if topLevelUserFacingResourceRef == nil {
+		topLevelUserFacingResourceRef = userFacingResourceRef
+	}
+
 	resource := &contract.Resource{
 		Uid:                 string(c.UID),
 		Topics:              c.Spec.Topics,
@@ -138,7 +146,7 @@ func (r *Reconciler) reconcileContractResource(ctx context.Context, c *kafkainte
 		Egresses:            []*contract.Egress{egress},
 		Auth:                nil, // Auth will be added by reconcileAuth
 		CloudEventOverrides: reconcileCEOverrides(c),
-		Reference:           userFacingResourceRef,
+		Reference:           topLevelUserFacingResourceRef,
 	}
 
 	if err := r.reconcileAuth(ctx, c, resource); err != nil {
@@ -294,6 +302,31 @@ func (r *Reconciler) reconcileUserFacingResourceRef(c *kafkainternals.Consumer) 
 		Uuid:      string(userFacingResource.UID),
 		Namespace: c.GetNamespace(),
 		Name:      userFacingResource.Name,
+	}
+	return ref, nil
+}
+
+func (r *Reconciler) reconcileTopLevelUserFacingResourceRef(c *kafkainternals.Consumer) (*contract.Reference, error) {
+
+	cg, err := r.ConsumerGroupLister.ConsumerGroups(c.GetNamespace()).Get(c.GetConsumerGroup().Name)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %s: %w", kafkainternals.ConsumerGroupGroupVersionKind.Kind, err)
+	}
+
+	userFacingResource := cg.GetTopLevelUserFacingResourceRef()
+	if userFacingResource == nil {
+		return nil, nil
+	}
+
+	ref := &contract.Reference{
+		Uuid:         string(userFacingResource.UID),
+		Namespace:    c.GetNamespace(),
+		Name:         userFacingResource.Name,
+		Kind:         userFacingResource.Kind,
+		GroupVersion: userFacingResource.APIVersion,
 	}
 	return ref, nil
 }

--- a/control-plane/pkg/reconciler/testing/objects_consumergroup.go
+++ b/control-plane/pkg/reconciler/testing/objects_consumergroup.go
@@ -248,3 +248,9 @@ func WithConfigmapOwnerRef(ownerref *metav1.OwnerReference) reconcilertesting.Co
 		cg.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*ownerref}
 	}
 }
+
+func WithTopLevelResourceRef(ref *corev1.ObjectReference) ConsumerGroupOption {
+	return func(cg *kafkainternals.ConsumerGroup) {
+		cg.Spec.TopLevelResourceRef = ref
+	}
+}

--- a/control-plane/pkg/reconciler/trigger/v2/triggerv2.go
+++ b/control-plane/pkg/reconciler/trigger/v2/triggerv2.go
@@ -209,6 +209,13 @@ func (r *Reconciler) reconcileConsumerGroup(ctx context.Context, broker *eventin
 			},
 		},
 		Spec: internalscg.ConsumerGroupSpec{
+			TopLevelResourceRef: &corev1.ObjectReference{
+				APIVersion: eventing.SchemeGroupVersion.String(),
+				Kind:       "Broker",
+				Name:       broker.Name,
+				Namespace:  broker.Namespace,
+				UID:        broker.UID,
+			},
 			Template: internalscg.ConsumerTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/control-plane/pkg/reconciler/trigger/v2/triggerv2_test.go
+++ b/control-plane/pkg/reconciler/trigger/v2/triggerv2_test.go
@@ -126,6 +126,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerFilters(NewConsumerSpecFilters()),
 						ConsumerReply(ConsumerTopicReply()),
 					)),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			WantEvents: []string{
@@ -187,6 +188,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerFilters(NewConsumerSpecFilters()),
 						ConsumerReply(ConsumerTopicReply()),
 					)),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
@@ -241,6 +243,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerFilters(NewConsumerSpecFilters()),
 						ConsumerReply(ConsumerTopicReply()),
 					)),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{
@@ -296,6 +299,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerFilters(NewConsumerSpecFilters()),
 						ConsumerReply(ConsumerTopicReply()),
 					)),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			WantEvents: []string{
@@ -403,6 +407,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerReply(ConsumerTopicReply()),
 						)),
 						ConsumerGroupReady,
+						withBrokerTopLevelResourceRef(),
 					),
 				},
 			},
@@ -448,6 +453,7 @@ func TestReconcileKind(t *testing.T) {
 					WithConsumerGroupMetaLabels(OwnerAsTriggerLabel),
 					WithConsumerGroupLabels(ConsumerTriggerLabel),
 					ConsumerGroupReady,
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key:         testKey,
@@ -472,6 +478,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerReply(ConsumerTopicReply()),
 						)),
 						ConsumerGroupReady,
+						withBrokerTopLevelResourceRef(),
 					),
 				},
 			},
@@ -515,6 +522,7 @@ func TestReconcileKind(t *testing.T) {
 					WithConsumerGroupOwnerRef(kmeta.NewControllerRef(newTrigger())),
 					WithConsumerGroupMetaLabels(OwnerAsTriggerLabel),
 					WithConsumerGroupLabels(ConsumerTriggerLabel),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key:         testKey,
@@ -537,6 +545,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerFilters(NewConsumerSpecFilters()),
 							ConsumerReply(ConsumerTopicReply()),
 						)),
+						withBrokerTopLevelResourceRef(),
 					),
 				},
 			},
@@ -597,6 +606,7 @@ func TestReconcileKind(t *testing.T) {
 							},
 						}),
 					)),
+					withBrokerTopLevelResourceRef(),
 				),
 				NewLegacySASLSecret(ConfigMapNamespace, "secret-1"),
 			},
@@ -627,6 +637,7 @@ func TestReconcileKind(t *testing.T) {
 								},
 							}),
 						)),
+						withBrokerTopLevelResourceRef(),
 					),
 				},
 			},
@@ -682,6 +693,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 					ConsumerGroupReady,
 					ConsumerGroupReplicas(1),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -736,6 +748,7 @@ func TestReconcileKind(t *testing.T) {
 						ConsumerReply(ConsumerTopicReply()),
 					)),
 					ConsumerGroupReplicas(1),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -791,6 +804,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 					WithConsumerGroupFailed("failed", "failed"),
 					ConsumerGroupReplicas(1),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -845,6 +859,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 					WithDeadLetterSinkURI(url.String()),
 					ConsumerGroupReplicas(1),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -992,6 +1007,7 @@ func TestReconcileKind(t *testing.T) {
 					WithConsumerGroupMetaLabels(OwnerAsTriggerLabel),
 					WithConsumerGroupLabels(ConsumerTriggerLabel),
 					ConsumerGroupReady,
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key:         testKey,
@@ -1015,6 +1031,7 @@ func TestReconcileKind(t *testing.T) {
 							ConsumerReply(ConsumerTopicReply()),
 						)),
 						ConsumerGroupReady,
+						withBrokerTopLevelResourceRef(),
 					),
 				},
 			},
@@ -1073,6 +1090,7 @@ func TestReconcileKind(t *testing.T) {
 					)),
 					ConsumerGroupReady,
 					ConsumerGroupReplicas(1),
+					withBrokerTopLevelResourceRef(),
 				),
 			},
 			Key: testKey,
@@ -1171,4 +1189,14 @@ func removeFinalizers() clientgotesting.PatchActionImpl {
 	patch := `{"metadata":{"finalizers":[],"resourceVersion":""}}`
 	action.Patch = []byte(patch)
 	return action
+}
+
+func withBrokerTopLevelResourceRef() ConsumerGroupOption {
+	return WithTopLevelResourceRef(&corev1.ObjectReference{
+		APIVersion: eventing.SchemeGroupVersion.String(),
+		Kind:       "Broker",
+		Namespace:  BrokerNamespace,
+		Name:       BrokerName,
+		UID:        BrokerUUID,
+	})
 }


### PR DESCRIPTION
Previously to v2, we were setting `name` to the Broker or Channel name of the resource.

Cherry-pick of https://github.com/knative-extensions/eventing-kafka-broker/pull/4120