### PR TITLE
[release-v1.15] Dockerfiles and build changes for hermetic Java builds

### DIFF
--- a/data-plane/contract/pom.xml
+++ b/data-plane/contract/pom.xml
@@ -39,16 +39,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.ec4j.maven</groupId>
-        <artifactId>editorconfig-maven-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
 </project>

--- a/data-plane/pom.xml
+++ b/data-plane/pom.xml
@@ -431,6 +431,10 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
           <groupId>com.google.cloud.tools</groupId>
           <artifactId>jib-maven-plugin</artifactId>
           <version>${jib.version}</version>
@@ -461,33 +465,12 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.ec4j.maven</groupId>
-          <artifactId>editorconfig-maven-plugin</artifactId>
-          <version>${maven.editorconfig.plugin.version}</version>
-          <executions>
-            <execution>
-              <id>check</id>
-              <phase>verify</phase>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
-          <configuration>
-            <excludes>
-              <exclude>.dockerignore</exclude>
-              <exclude>config/***</exclude>
-              <exclude>.mvn/***</exclude>
-            </excludes>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven.surefire.plugin.version}</version>
           <configuration>
             <systemPropertyVariables>
-                <net.bytebuddy.experimental>true</net.bytebuddy.experimental>
+              <net.bytebuddy.experimental>true</net.bytebuddy.experimental>
             </systemPropertyVariables>
             <!-- This is required for the jacoco maven plugin -->
             <argLine>${argLine}</argLine>

--- a/openshift/ci-operator/static-images/dispatcher/Dockerfile
+++ b/openshift/ci-operator/static-images/dispatcher/Dockerfile
@@ -28,36 +28,21 @@ COPY /data-plane/receiver-loom/pom.xml receiver-loom/pom.xml
 COPY /data-plane/dispatcher/pom.xml dispatcher/pom.xml
 COPY /data-plane/dispatcher-loom/pom.xml dispatcher-loom/pom.xml
 COPY /data-plane/contract/pom.xml contract/pom.xml
-COPY /data-plane/mvnw .
-COPY /data-plane/.mvn/wrapper .mvn/wrapper
 
 # Install dependencies. Note: don't build a single submodule (receiver or dispatcher) since it just slows down
 # consecutive builds.
-RUN ./mvnw install -am -DskipTests -Drelease -Dlicense.skip -Deditorconfig.skip --no-transfer-progress
+RUN mvn install -am -DskipTests -Drelease -Dlicense.skip -Deditorconfig.skip --no-transfer-progress
 
 COPY /data-plane/ .
 
-RUN ./mvnw package -pl=dispatcher-loom -Drelease -am -DskipTests -Deditorconfig.skip --no-transfer-progress
+RUN mvn package -pl=dispatcher-loom -Drelease -am -DskipTests -Deditorconfig.skip --no-transfer-progress
 
 RUN mkdir /app && cp /build/dispatcher-loom/target/dispatcher-loom-1.0-SNAPSHOT.jar /app/app.jar
 
 # We use the generated JDK from the "builder" image, so we can just go with the ubi-minimal
 FROM registry.access.redhat.com/ubi8/openjdk-21-runtime as running
 
-EXPOSE 8080 8778 9779
-
 USER 185
-
-LABEL \
-      com.redhat.component="openshift-serverless-1-eventing-kafka-broker-dispatcher-rhel8-container" \
-      name="openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8" \
-      version=$VERSION \
-      summary="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Dispatcher" \
-      maintainer="serverless-support@redhat.com" \
-      description="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Dispatcher" \
-      io.k8s.display-name="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Dispatcher" \
-      io.k8s.description="Red Hat OpenShift Serverless Eventing Kafka Broker Dispatcher" \
-      io.openshift.tags=Dispatcher
 
 COPY --from=builder /app /app
 

--- a/openshift/ci-operator/static-images/dispatcher/hermetic/Dockerfile
+++ b/openshift/ci-operator/static-images/dispatcher/hermetic/Dockerfile
@@ -1,0 +1,55 @@
+#
+# Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ARG JAVA_BUILDER=registry.access.redhat.com/ubi8/openjdk-21
+ARG JAVA_RUNTIME=registry.access.redhat.com/ubi8/openjdk-21-runtime
+ARG DEPS_IMAGE
+ARG VERSION=""
+
+FROM $DEPS_IMAGE AS deps
+
+FROM $JAVA_BUILDER AS builder
+
+USER root
+
+WORKDIR /build
+
+COPY --from=deps /third_party/maven/ /third_party/maven/
+
+COPY /data-plane .
+
+RUN mvn -Dmaven.repo.local=/third_party/maven --offline package -pl=dispatcher-loom -Drelease -am -DskipTests --no-transfer-progress
+
+RUN mkdir /app && cp /build/dispatcher-loom/target/dispatcher-loom-1.0-SNAPSHOT.jar /app/app.jar
+
+FROM $JAVA_RUNTIME AS running
+
+USER 185
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-eventing-kafka-broker-dispatcher-rhel8-container" \
+      name="openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Dispatcher" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Dispatcher" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Dispatcher" \
+      io.k8s.description="Red Hat OpenShift Serverless Eventing Kafka Broker Dispatcher" \
+      io.openshift.tags=dispatcher
+
+COPY --from=builder /app /app
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/openshift/ci-operator/static-images/dispatcher/hermetic/Dockerfile.deps
+++ b/openshift/ci-operator/static-images/dispatcher/hermetic/Dockerfile.deps
@@ -14,38 +14,21 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/openjdk-21 as builder
+ARG JAVA_BUILDER=registry.access.redhat.com/ubi8/openjdk-21
 
-WORKDIR /build
+FROM $JAVA_BUILDER
 
 USER root
 
+WORKDIR /build
+
 COPY /data-plane/pom.xml .
-COPY /data-plane/.editorconfig .
 COPY /data-plane/core/pom.xml core/pom.xml
 COPY /data-plane/receiver/pom.xml receiver/pom.xml
 COPY /data-plane/receiver-loom/pom.xml receiver-loom/pom.xml
 COPY /data-plane/dispatcher/pom.xml dispatcher/pom.xml
 COPY /data-plane/dispatcher-loom/pom.xml dispatcher-loom/pom.xml
 COPY /data-plane/contract/pom.xml contract/pom.xml
-COPY /data-plane/mvnw .
-COPY /data-plane/.mvn/wrapper .mvn/wrapper
 
-# Install dependencies. Note: don't build a single submodule (receiver or dispatcher) since it just slows down
-# consecutive builds.
-RUN mvn install -am -DskipTests -Drelease -Dlicense.skip -Deditorconfig.skip --no-transfer-progress
-
-COPY /data-plane/ .
-
-RUN mvn package -pl=receiver-loom -Drelease -am -DskipTests -Deditorconfig.skip --no-transfer-progress
-
-RUN mkdir /app && cp /build/receiver-loom/target/receiver-loom-1.0-SNAPSHOT.jar /app/app.jar
-
-# We use the generated JDK from the "builder" image, so we can just go with the ubi-minimal
-FROM registry.access.redhat.com/ubi8/openjdk-21-runtime as running
-
-USER 185
-
-COPY --from=builder /app /app
-
-ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+RUN mvn package dependency:go-offline -Drelease -DskipTests -Dmaven.repo.local=/third_party/maven
+RUN find /third_party/maven/ -path "*_remote.repositories" | xargs -I{} rm {}

--- a/openshift/ci-operator/static-images/receiver/hermetic/Dockerfile
+++ b/openshift/ci-operator/static-images/receiver/hermetic/Dockerfile
@@ -1,0 +1,55 @@
+#
+# Copyright © 2018 Knative Authors (knative-dev@googlegroups.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ARG JAVA_BUILDER=registry.access.redhat.com/ubi8/openjdk-21
+ARG JAVA_RUNTIME=registry.access.redhat.com/ubi8/openjdk-21-runtime
+ARG DEPS_IMAGE
+ARG VERSION=""
+
+FROM $DEPS_IMAGE AS deps
+
+FROM $JAVA_BUILDER AS builder
+
+USER root
+
+WORKDIR /build
+
+COPY --from=deps /third_party/maven/ /third_party/maven/
+
+COPY /data-plane .
+
+RUN mvn -Dmaven.repo.local=/third_party/maven --offline package -pl=receiver-loom -Drelease -am -DskipTests --no-transfer-progress
+
+RUN mkdir /app && cp /build/receiver-loom/target/receiver-loom-1.0-SNAPSHOT.jar /app/app.jar
+
+FROM $JAVA_RUNTIME AS running
+
+USER 185
+
+LABEL \
+      com.redhat.component="openshift-serverless-1-eventing-kafka-broker-receiver-rhel8-container" \
+      name="openshift-serverless-1/eventing-kafka-broker-receiver-rhel8" \
+      version=$VERSION \
+      summary="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Receiver" \
+      maintainer="serverless-support@redhat.com" \
+      description="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Receiver" \
+      io.k8s.display-name="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Receiver" \
+      io.k8s.description="Red Hat OpenShift Serverless Eventing Kafka Broker Receiver" \
+      io.openshift.tags=receiver
+
+COPY --from=builder /app /app
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/openshift/ci-operator/static-images/receiver/hermetic/Dockerfile.deps
+++ b/openshift/ci-operator/static-images/receiver/hermetic/Dockerfile.deps
@@ -14,38 +14,21 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/openjdk-21 as builder
+ARG JAVA_BUILDER=registry.access.redhat.com/ubi8/openjdk-21
 
-WORKDIR /build
+FROM $JAVA_BUILDER
 
 USER root
 
+WORKDIR /build
+
 COPY /data-plane/pom.xml .
-COPY /data-plane/.editorconfig .
 COPY /data-plane/core/pom.xml core/pom.xml
 COPY /data-plane/receiver/pom.xml receiver/pom.xml
 COPY /data-plane/receiver-loom/pom.xml receiver-loom/pom.xml
 COPY /data-plane/dispatcher/pom.xml dispatcher/pom.xml
 COPY /data-plane/dispatcher-loom/pom.xml dispatcher-loom/pom.xml
 COPY /data-plane/contract/pom.xml contract/pom.xml
-COPY /data-plane/mvnw .
-COPY /data-plane/.mvn/wrapper .mvn/wrapper
 
-# Install dependencies. Note: don't build a single submodule (receiver or dispatcher) since it just slows down
-# consecutive builds.
-RUN mvn install -am -DskipTests -Drelease -Dlicense.skip -Deditorconfig.skip --no-transfer-progress
-
-COPY /data-plane/ .
-
-RUN mvn package -pl=receiver-loom -Drelease -am -DskipTests -Deditorconfig.skip --no-transfer-progress
-
-RUN mkdir /app && cp /build/receiver-loom/target/receiver-loom-1.0-SNAPSHOT.jar /app/app.jar
-
-# We use the generated JDK from the "builder" image, so we can just go with the ubi-minimal
-FROM registry.access.redhat.com/ubi8/openjdk-21-runtime as running
-
-USER 185
-
-COPY --from=builder /app /app
-
-ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+RUN mvn package dependency:go-offline -Drelease -DskipTests -Dmaven.repo.local=/third_party/maven
+RUN find /third_party/maven/ -path "*_remote.repositories" | xargs -I{} rm {}


### PR DESCRIPTION
To support hermetic builds for Java, we will follow the POC here: https://github.com/openshift-knative/eventing-kafka-broker/pull/1273.

While this currently doesn't pass the enterprise contract, I've validated that it will in the future with Konflux team here: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1727247236771179 with the addition of `KONFLUX-298`.

This brings the dockerfiles and maven build changes from the POC https://github.com/openshift-knative/eventing-kafka-broker/pull/1273 and they will be used by pipelines introduced in https://github.com/openshift-knative/hack/pull/304

