### PR TITLE
SRVKE-1664: [release-v1.14] Disable disallow unknown fields

### DIFF
--- a/control-plane/cmd/webhook-kafka/main.go
+++ b/control-plane/cmd/webhook-kafka/main.go
@@ -140,7 +140,7 @@ func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 		ctxFunc,
 
 		// Whether to disallow unknown fields.
-		true,
+		false,
 	)
 }
 


### PR DESCRIPTION
```
=== RUN   TestServerlessUpgradeContinual/Run/Steps/DowngradeWith/DowngradeServerless
    triggerv2_downgrade.go:46: failed to downgrade from triggerv2 admission webhook "validation.webhook.kafka.eventing.knative.dev" denied the request: decoding request failed: cannot decode incoming old object: json: unknown field "topLevelResourceRef"
--- FAIL: TestServerlessUpgradeContinual/Run/Steps/DowngradeWith/DowngradeServerless (94.81s)
```