### PR TITLE
[release-v1.14] Fix EOF errors when using `SASL_SSL` `PLAIN`

### DIFF
--- a/control-plane/pkg/reconciler/consumergroup/consumergroup.go
+++ b/control-plane/pkg/reconciler/consumergroup/consumergroup.go
@@ -293,14 +293,14 @@ func (r *Reconciler) reconcileStatusSelector(cg *kafkainternals.ConsumerGroup) {
 }
 
 func (r *Reconciler) deleteConsumerGroupMetadata(ctx context.Context, cg *kafkainternals.ConsumerGroup) error {
-	kafakSecret, err := r.newAuthSecret(ctx, cg)
+	kafkaSecret, err := r.newAuthSecret(ctx, cg)
 	if err != nil {
 		return fmt.Errorf("failed to get secret for Kafka cluster auth: %w", err)
 	}
 
 	bootstrapServers := kafka.BootstrapServersArray(cg.Spec.Template.Spec.Configs.Configs["bootstrap.servers"])
 
-	kafkaClusterAdminClient, err := r.GetKafkaClusterAdmin(ctx, bootstrapServers, kafakSecret)
+	kafkaClusterAdminClient, err := r.GetKafkaClusterAdmin(ctx, bootstrapServers, kafkaSecret)
 	if err != nil {
 		return fmt.Errorf("cannot obtain Kafka cluster admin, %w", err)
 	}


### PR DESCRIPTION
The consumergroup reconciler was using the legacy secret format resolver to configure the Sarama client even in the Kafka Broker case.

We can't really add a E2E regression test as strimzi doesn't support `SASL/PLAIN`: see `strimzi/strimzi-kafka-operator/issues/2221`