### PR TITLE
[release-v1.15] Complete Consumer verticle stop promise only after closing dependencies

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/ConsumerVerticle.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/impl/consumer/ConsumerVerticle.java
@@ -65,14 +65,14 @@ public abstract class ConsumerVerticle extends AbstractVerticle {
 
     @Override
     public void stop(Promise<Void> stopPromise) {
-        logger.info("Stopping consumer {}", consumerVerticleContext.getLoggingKeyValue());
+        logger.info("Stopping consumer verticle {}", consumerVerticleContext.getLoggingKeyValue());
 
         AsyncCloseable.compose(this.recordDispatcher, this.closeable, this.consumer::close)
                 .close()
-                .onComplete(
-                        r -> logger.info("Consumer verticle closed {}", consumerVerticleContext.getLoggingKeyValue()));
-
-        stopPromise.tryComplete();
+                .onComplete(r -> {
+                    stopPromise.tryComplete();
+                    logger.info("Consumer verticle closed {}", consumerVerticleContext.getLoggingKeyValue());
+                });
     }
 
     public void setConsumer(ReactiveKafkaConsumer<Object, CloudEvent> consumer) {


### PR DESCRIPTION
Completing the stop promise before the dependencies (dispatcher, client, etc) before will cause the WebClient to be closed.