### PR TITLE
[release-v1.15] Fix labels in static hermetic images

### DIFF
--- a/openshift/ci-operator/static-images/dispatcher/hermetic/Dockerfile
+++ b/openshift/ci-operator/static-images/dispatcher/hermetic/Dockerfile
@@ -17,7 +17,6 @@
 ARG JAVA_BUILDER=registry.access.redhat.com/ubi8/openjdk-21
 ARG JAVA_RUNTIME=registry.access.redhat.com/ubi8/openjdk-21-runtime
 ARG DEPS_IMAGE
-ARG VERSION=""
 
 FROM $DEPS_IMAGE AS deps
 
@@ -36,6 +35,7 @@ RUN mvn -Dmaven.repo.local=/third_party/maven --offline package -pl=dispatcher-l
 RUN mkdir /app && cp /build/dispatcher-loom/target/dispatcher-loom-1.0-SNAPSHOT.jar /app/app.jar
 
 FROM $JAVA_RUNTIME AS running
+ARG VERSION=""
 
 USER 185
 
@@ -43,6 +43,7 @@ LABEL \
       com.redhat.component="openshift-serverless-1-eventing-kafka-broker-dispatcher-rhel8-container" \
       name="openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8" \
       version=$VERSION \
+      release=$VERSION \
       summary="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Dispatcher" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Dispatcher" \

--- a/openshift/ci-operator/static-images/receiver/hermetic/Dockerfile
+++ b/openshift/ci-operator/static-images/receiver/hermetic/Dockerfile
@@ -17,7 +17,6 @@
 ARG JAVA_BUILDER=registry.access.redhat.com/ubi8/openjdk-21
 ARG JAVA_RUNTIME=registry.access.redhat.com/ubi8/openjdk-21-runtime
 ARG DEPS_IMAGE
-ARG VERSION=""
 
 FROM $DEPS_IMAGE AS deps
 
@@ -36,6 +35,7 @@ RUN mvn -Dmaven.repo.local=/third_party/maven --offline package -pl=receiver-loo
 RUN mkdir /app && cp /build/receiver-loom/target/receiver-loom-1.0-SNAPSHOT.jar /app/app.jar
 
 FROM $JAVA_RUNTIME AS running
+ARG VERSION=""
 
 USER 185
 
@@ -43,6 +43,7 @@ LABEL \
       com.redhat.component="openshift-serverless-1-eventing-kafka-broker-receiver-rhel8-container" \
       name="openshift-serverless-1/eventing-kafka-broker-receiver-rhel8" \
       version=$VERSION \
+      release=$VERSION \
       summary="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Receiver" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Receiver" \


### PR DESCRIPTION
Populate the `version` and `release` labels correctly. Should also prevent the following Konflux warning:

```
"failed": [
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description) are present in the container metadata.",
                "help": "Check Check HasRequiredLabel encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Add the following labels to your Dockerfile or Containerfile: name, vendor, version, release, summary, description",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            }
        ],
```