### PR TITLE
Remove .editorconfig copy in Dockerfile

### DIFF
--- a/openshift/ci-operator/static-images/dispatcher/Dockerfile
+++ b/openshift/ci-operator/static-images/dispatcher/Dockerfile
@@ -21,7 +21,6 @@ WORKDIR /build
 USER root
 
 COPY /data-plane/pom.xml .
-COPY /data-plane/.editorconfig .
 COPY /data-plane/core/pom.xml core/pom.xml
 COPY /data-plane/receiver/pom.xml receiver/pom.xml
 COPY /data-plane/receiver-loom/pom.xml receiver-loom/pom.xml

--- a/openshift/ci-operator/static-images/receiver/Dockerfile
+++ b/openshift/ci-operator/static-images/receiver/Dockerfile
@@ -21,7 +21,6 @@ WORKDIR /build
 USER root
 
 COPY /data-plane/pom.xml .
-COPY /data-plane/.editorconfig .
 COPY /data-plane/core/pom.xml core/pom.xml
 COPY /data-plane/receiver/pom.xml receiver/pom.xml
 COPY /data-plane/receiver-loom/pom.xml receiver-loom/pom.xml


### PR DESCRIPTION
Remove `.editorconfig` copy in Dockerfile as file was removed in https://github.com/knative-extensions/eventing-kafka-broker/pull/4096/files

Should help on https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_eventing-kafka-broker/1489/pull-ci-openshift-knative-eventing-kafka-broker-release-next-417-images/1889113961492647936