### PR TITLE
Run hack generate tool directly

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -181,10 +181,7 @@ function run_e2e_encryption_auth_tests(){
 }
 
 function install_hack_tools() {
-	git clone https://github.com/openshift-knative/hack.git /tmp/hack
-	cd /tmp/hack && \
-	  go install github.com/openshift-knative/hack/cmd/generate && \
-	  go install github.com/openshift-knative/hack/cmd/sobranch && \
-	  cd - && rm -rf /tmp/hack
+	GOFLAGS='' go install github.com/openshift-knative/hack/cmd/generate@latest && \
+	GOFLAGS='' go install github.com/openshift-knative/hack/cmd/sobranch@latest
 	return $?
 }

--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -4,16 +4,7 @@ set -euo pipefail
 
 repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
 
-tmp_dir=$(mktemp -d)
-git clone --branch main https://github.com/openshift-knative/hack "$tmp_dir"
-
-pushd "$tmp_dir"
-go install github.com/openshift-knative/hack/cmd/generate
-popd
-
-rm -rf "$tmp_dir"
-
-$(go env GOPATH)/bin/generate \
+GOFLAGS='' go run github.com/openshift-knative/hack/cmd/generate@latest \
   --root-dir "${repo_root_dir}" \
   --generators dockerfile \
   --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17"


### PR DESCRIPTION
Fixing current issues with installing hack tools (e.g. [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_eventing-kafka-broker/1535/pull-ci-openshift-knative-eventing-kafka-broker-release-v1.17-417-test-conformance/1891811011204222976))

```
Cloning into '/tmp/hack'...
+ cd /tmp/hack
+ go install github.com/openshift-knative/hack/cmd/generate
go: inconsistent vendoring in /tmp/hack:
...
```