### PR TITLE
Use default builder image in dockerfile generator

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -6,5 +6,4 @@ repo_root_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")/..
 
 GOFLAGS='' go run github.com/openshift-knative/hack/cmd/generate@latest \
   --root-dir "${repo_root_dir}" \
-  --generators dockerfile \
-  --dockerfile-image-builder-fmt "registry.ci.openshift.org/openshift/release:rhel-8-release-golang-%s-openshift-4.17"
+  --generators dockerfile


### PR DESCRIPTION
Fallback to default builder image based on golang & OCP image version (https://github.com/openshift-knative/hack/pull/601)