### PR TITLE
[release-v1.16] Create schedulers on demand

### DIFF
--- a/openshift/patches/sharedmain_MainNamed.patch
+++ b/openshift/patches/sharedmain_MainNamed.patch
@@ -1,0 +1,32 @@
+diff --git a/vendor/knative.dev/pkg/injection/sharedmain/main.go b/vendor/knative.dev/pkg/injection/sharedmain/main.go
+index 86bb1e340..44789f04b 100644
+--- a/vendor/knative.dev/pkg/injection/sharedmain/main.go
++++ b/vendor/knative.dev/pkg/injection/sharedmain/main.go
+@@ -146,6 +146,16 @@ var (
+ 	WebhookMainWithConfig  = MainWithConfig
+ )
+ 
++//type DisabledControllersKey struct{}
++
++// Store the most recently parsed disabled controllers
++var currentDisabledControllers []string
++
++// GetDisabledControllers returns the list of currently disabled controllers
++func GetDisabledControllers() []string {
++	return currentDisabledControllers
++}
++
+ // MainNamed runs the generic main flow for controllers and webhooks.
+ //
+ // In addition to the MainWithConfig flow, it defines a `disabled-controllers` flag that allows disabling controllers
+@@ -156,6 +166,10 @@ func MainNamed(ctx context.Context, component string, ctors ...injection.NamedCo
+ 	// HACK: This parses flags, so the above should be set once this runs.
+ 	cfg := injection.ParseAndGetRESTConfigOrDie()
+ 
++	// Split the disabled controllers string and store them
++	disabledControllersList := strings.Split(*disabledControllers, ",")
++	currentDisabledControllers = disabledControllersList
++
+ 	enabledCtors := enabledControllers(strings.Split(*disabledControllers, ","), ctors)
+ 	MainWithConfig(ctx, component, cfg, toControllerConstructors(enabledCtors)...)
+ }

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -6,6 +6,7 @@ source $(dirname $0)/resolve.sh
 
 GITHUB_ACTIONS=true $(dirname $0)/../../hack/update-codegen.sh
 git apply openshift/patches/rekt-serviceaccounts-delete.patch
+git apply openshift/patches/sharedmain_MainNamed.patch
 
 # Eventing core will bring the config tracing ConfigMap, so remove it from heret
 rm -f control-plane/config/eventing-kafka-broker/200-controller/100-config-tracing.yaml

--- a/vendor/knative.dev/pkg/injection/sharedmain/main.go
+++ b/vendor/knative.dev/pkg/injection/sharedmain/main.go
@@ -146,6 +146,16 @@ var (
 	WebhookMainWithConfig  = MainWithConfig
 )
 
+//type DisabledControllersKey struct{}
+
+// Store the most recently parsed disabled controllers
+var currentDisabledControllers []string
+
+// GetDisabledControllers returns the list of currently disabled controllers
+func GetDisabledControllers() []string {
+	return currentDisabledControllers
+}
+
 // MainNamed runs the generic main flow for controllers and webhooks.
 //
 // In addition to the MainWithConfig flow, it defines a `disabled-controllers` flag that allows disabling controllers
@@ -155,6 +165,10 @@ func MainNamed(ctx context.Context, component string, ctors ...injection.NamedCo
 
 	// HACK: This parses flags, so the above should be set once this runs.
 	cfg := injection.ParseAndGetRESTConfigOrDie()
+
+	// Split the disabled controllers string and store them
+	disabledControllersList := strings.Split(*disabledControllers, ",")
+	currentDisabledControllers = disabledControllersList
 
 	enabledCtors := enabledControllers(strings.Split(*disabledControllers, ","), ctors)
 	MainWithConfig(ctx, component, cfg, toControllerConstructors(enabledCtors)...)


### PR DESCRIPTION
SRVKE-1714

schedulers are created in the never disabled `consumergroup controller`, but when components on `KnativeKafka` are _not_ `enabled`, they report 404 from the API server.

This PR removes the undesired load from the API server as it does NOT create schedulers for _disabled_ components dispatchers (e.g. trigger, source or channel)