### PR TITLE
[release-v1.16] Run keda obj deletion only if the feature was previously enabled, to avoid GET requests for KEDA resources against the API server on each reconcilation

### DIFF
--- a/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_lifecycle.go
+++ b/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_lifecycle.go
@@ -26,6 +26,7 @@ const (
 	ConditionConsumerGroupConsumers          apis.ConditionType = "Consumers"
 	ConditionConsumerGroupConsumersScheduled apis.ConditionType = "ConsumersScheduled"
 	ConditionAutoscaling                     apis.ConditionType = "Autoscaler"
+	AutoscalerDisabled                                          = "AutoscalerDisabled"
 	// Labels
 	KafkaChannelNameLabel           = "kafkachannel-name"
 	ConsumerLabelSelector           = "kafka.eventing.knative.dev/metadata.uid"
@@ -98,7 +99,7 @@ func (cg *ConsumerGroup) MarkAutoscalerSucceeded() {
 }
 
 func (cg *ConsumerGroup) MarkAutoscalerDisabled() {
-	cg.GetConditionSet().Manage(cg.GetStatus()).MarkTrueWithReason(ConditionAutoscaling, "AutoscalerDisabled", "")
+	cg.GetConditionSet().Manage(cg.GetStatus()).MarkTrueWithReason(ConditionAutoscaling, AutoscalerDisabled, "")
 }
 
 func (cg *ConsumerGroup) MarkAutoscalerFailed(reason string, err error) error {

--- a/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_lifecycle.go
+++ b/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_lifecycle.go
@@ -98,7 +98,7 @@ func (cg *ConsumerGroup) MarkAutoscalerSucceeded() {
 }
 
 func (cg *ConsumerGroup) MarkAutoscalerDisabled() {
-	cg.GetConditionSet().Manage(cg.GetStatus()).MarkTrueWithReason(ConditionAutoscaling, "Autoscaler is disabled", "")
+	cg.GetConditionSet().Manage(cg.GetStatus()).MarkTrueWithReason(ConditionAutoscaling, "AutoscalerDisabled", "")
 }
 
 func (cg *ConsumerGroup) MarkAutoscalerFailed(reason string, err error) error {

--- a/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_types.go
+++ b/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_types.go
@@ -230,6 +230,18 @@ func (cg *ConsumerGroup) IsNotScheduled() bool {
 	return cond.IsFalse() || cond.IsUnknown()
 }
 
+func (cg *ConsumerGroup) IsAutoscalerNotDisabled() bool {
+	condition := cg.Status.GetCondition(ConditionAutoscaling)
+
+	// If condition doesn't exist or is not true, it's not in "disabled" state
+	if condition == nil || condition.Status != corev1.ConditionTrue {
+		return true
+	}
+
+	// If condition is True but reason is not "AutoscalerDisabled", then it's actively enabled
+	return condition.Reason != "AutoscalerDisabled"
+}
+
 func (cg *ConsumerGroup) HasDeadLetterSink() bool {
 	return hasDeadLetterSink(cg.Spec.Template.Spec.Delivery)
 }

--- a/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_types.go
+++ b/control-plane/pkg/apis/internalskafkaeventing/v1alpha1/consumer_group_types.go
@@ -238,8 +238,8 @@ func (cg *ConsumerGroup) IsAutoscalerNotDisabled() bool {
 		return true
 	}
 
-	// If condition is True but reason is not "AutoscalerDisabled", then it's actively enabled
-	return condition.Reason != "AutoscalerDisabled"
+	// If condition is True but reason is not "autoscaler is disabled", then it's actively enabled
+	return condition.Reason != AutoscalerDisabled
 }
 
 func (cg *ConsumerGroup) HasDeadLetterSink() bool {


### PR DESCRIPTION
backport of upstream PR 4356

For https://issues.redhat.com/browse/SRVKE-1721