### PR TITLE
[release-v1.16] SRVKE-1705 Fix initializer ocp

### DIFF
--- a/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
+++ b/data-plane/dispatcher/src/main/java/dev/knative/eventing/kafka/broker/dispatcher/main/ConsumerVerticleBuilder.java
@@ -79,17 +79,17 @@ public class ConsumerVerticleBuilder {
         return (vertx, consumerVerticle) -> {
             Promise<Void> promise = Promise.promise();
             consumerVerticleContext
-                .getAuthProvider()
-                .getCredentials(consumerVerticleContext.getResource())
-                .onSuccess(credentials -> {
-                try {
-                    build(vertx, consumerVerticle, credentials);
-                    promise.complete();
-                } catch (Exception e) {
-                    promise.fail(e);
-                    }
-                })
-                .onFailure(promise::fail);
+                    .getAuthProvider()
+                    .getCredentials(consumerVerticleContext.getResource())
+                    .onSuccess(credentials -> {
+                        try {
+                            build(vertx, consumerVerticle, credentials);
+                            promise.complete();
+                        } catch (Exception e) {
+                            promise.fail(e);
+                        }
+                    })
+                    .onFailure(promise::fail);
             return promise.future();
         };
     }


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/SRVKE-1705 

```
Mar 03, 2025 7:20:11 PM io.vertx.core.impl.ContextImpl
SEVERE: Unhandled exception
java.lang.NullPointerException: Cannot invoke "dev.knative.eventing.kafka.broker.core.ReactiveKafkaConsumer.exceptionHandler(io.vertx.core.Handler)" because "this.consumer" is null
	at dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.ConsumerVerticle.lambda$start$0(ConsumerVerticle.java:60)
	at io.vertx.core.impl.future.FutureImpl$1.onSuccess(FutureImpl.java:91)
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
	at io.vertx.core.impl.future.FutureImpl.addListener(FutureImpl.java:231)
	at io.vertx.core.impl.future.FutureImpl.onSuccess(FutureImpl.java:87)
	at dev.knative.eventing.kafka.broker.dispatcher.impl.consumer.ConsumerVerticle.start(ConsumerVerticle.java:59)
	at io.vertx.core.impl.DeploymentManager.lambda$doDeploy$5(DeploymentManager.java:210)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:270)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:252)
	at io.vertx.core.impl.ContextInternal.lambda$runOnContext$0(ContextInternal.java:50)
	at io.vertx.core.impl.WorkerExecutor$1.execute(WorkerExecutor.java:70)
	at io.vertx.core.impl.WorkerTask.run(WorkerTask.java:56)
	at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:81)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

Adding a bit of defense coding here, since the consumer is set during the `build()` method, I have changed the initializer to  complete the `Promise` after `build()` has fully finished. Trying to avoid a potential race when the `start()` might use the consumer it was set.