### PR TITLE
WIP: [release-v1.17] Disable the controllers for KafkaNamespaced Broker/Trigger controllers to avoid issues.

### DIFF
--- a/control-plane/cmd/kafka-controller/main.go
+++ b/control-plane/cmd/kafka-controller/main.go
@@ -42,7 +42,6 @@ import (
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/consumergroup"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/sink"
 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/source"
-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/trigger"
 	triggerv2 "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/trigger/v2"
 )
 
@@ -102,21 +101,21 @@ func main() {
 			},
 		},
 
-		// Namespaced broker controller
-		injection.NamedControllerConstructor{
-			Name: "namespaced-broker-controller",
-			ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
-				return broker.NewNamespacedController(ctx, watcher, brokerEnv)
-			},
-		},
-
-		// Namespaced trigger controller
-		injection.NamedControllerConstructor{
-			Name: "namespaced-trigger-controller",
-			ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
-				return trigger.NewNamespacedController(ctx, watcher, brokerEnv)
-			},
-		},
+		//// Namespaced broker controller
+		//injection.NamedControllerConstructor{
+		//	Name: "namespaced-broker-controller",
+		//	ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
+		//		return broker.NewNamespacedController(ctx, watcher, brokerEnv)
+		//	},
+		//},
+		//
+		//// Namespaced trigger controller
+		//injection.NamedControllerConstructor{
+		//	Name: "namespaced-trigger-controller",
+		//	ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
+		//		return trigger.NewNamespacedController(ctx, watcher, brokerEnv)
+		//	},
+		//},
 
 		// Channel controller
 		injection.NamedControllerConstructor{

--- a/openshift/patches/disabled_KafkaNamespaced_Controllers
+++ b/openshift/patches/disabled_KafkaNamespaced_Controllers
@@ -1,0 +1,65 @@
+diff --git a/control-plane/cmd/kafka-controller/main.go b/control-plane/cmd/kafka-controller/main.go
+index fdcbc43de..ad608d6b2 100644
+--- a/control-plane/cmd/kafka-controller/main.go
++++ b/control-plane/cmd/kafka-controller/main.go
+@@ -42,7 +42,6 @@ import (
+ 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/consumergroup"
+ 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/sink"
+ 	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/source"
+-	"knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/trigger"
+ 	triggerv2 "knative.dev/eventing-kafka-broker/control-plane/pkg/reconciler/trigger/v2"
+ )
+ 
+@@ -102,21 +101,21 @@ func main() {
+ 			},
+ 		},
+ 
+-		// Namespaced broker controller
+-		injection.NamedControllerConstructor{
+-			Name: "namespaced-broker-controller",
+-			ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
+-				return broker.NewNamespacedController(ctx, watcher, brokerEnv)
+-			},
+-		},
+-
+-		// Namespaced trigger controller
+-		injection.NamedControllerConstructor{
+-			Name: "namespaced-trigger-controller",
+-			ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
+-				return trigger.NewNamespacedController(ctx, watcher, brokerEnv)
+-			},
+-		},
++		//// Namespaced broker controller
++		//injection.NamedControllerConstructor{
++		//	Name: "namespaced-broker-controller",
++		//	ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
++		//		return broker.NewNamespacedController(ctx, watcher, brokerEnv)
++		//	},
++		//},
++		//
++		//// Namespaced trigger controller
++		//injection.NamedControllerConstructor{
++		//	Name: "namespaced-trigger-controller",
++		//	ControllerConstructor: func(ctx context.Context, watcher configmap.Watcher) *controller.Impl {
++		//		return trigger.NewNamespacedController(ctx, watcher, brokerEnv)
++		//	},
++		//},
+ 
+ 		// Channel controller
+ 		injection.NamedControllerConstructor{
+diff --git a/test/reconciler-tests.sh b/test/reconciler-tests.sh
+index 6c345c997..ab8929032 100755
+--- a/test/reconciler-tests.sh
++++ b/test/reconciler-tests.sh
+@@ -39,8 +39,9 @@ fi
+ 
+ if [ "${BROKER_CLASS}" == "KafkaNamespaced" ]; then
+ 	# if flag exists, only test tests that are relevant to namespaced KafkaBroker
+-	echo "BROKER_CLASS is set to 'KafkaNamespaced'. Only running the relevant tests."
+-	go_test_e2e -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
++  #  echo "BROKER_CLASS is set to 'KafkaNamespaced'. Only running the relevant tests."
++  #  go_test_e2e -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
++  echo "BROKER_CLASS is set to 'KafkaNamespaced'. Skipping tests."
+ 	success
+ fi
+ 

--- a/test/reconciler-tests.sh
+++ b/test/reconciler-tests.sh
@@ -39,8 +39,9 @@ fi
 
 if [ "${BROKER_CLASS}" == "KafkaNamespaced" ]; then
 	# if flag exists, only test tests that are relevant to namespaced KafkaBroker
-	echo "BROKER_CLASS is set to 'KafkaNamespaced'. Only running the relevant tests."
-	go_test_e2e -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
+  #  echo "BROKER_CLASS is set to 'KafkaNamespaced'. Only running the relevant tests."
+  #  go_test_e2e -timeout=1h ./test/e2e_new/... || fail_test "E2E (new) suite failed"
+  echo "BROKER_CLASS is set to 'KafkaNamespaced'. Skipping tests."
 	success
 fi
 


### PR DESCRIPTION
Will be disabled on OCP, only.