### PR TITLE
Fix namespaced broker patch for upstream config changes

### DIFF
--- a/openshift/patches/namespaced_broker_copy_trustedca_cm.patch
+++ b/openshift/patches/namespaced_broker_copy_trustedca_cm.patch
@@ -1,9 +1,9 @@
 diff --git a/control-plane/pkg/reconciler/broker/namespaced_broker.go b/control-plane/pkg/reconciler/broker/namespaced_broker.go
-index 759c13e94..c5a1fb07a 100644
+index 8745fada7..8612d3846 100644
 --- a/control-plane/pkg/reconciler/broker/namespaced_broker.go
 +++ b/control-plane/pkg/reconciler/broker/namespaced_broker.go
-@@ -388,6 +388,7 @@ func (r *NamespacedReconciler) configMapsFromSystemNamespace(broker *eventing.Br
- 		"config-tracing",
+@@ -412,6 +412,7 @@ func (r *NamespacedReconciler) configMapsFromSystemNamespace(broker *eventing.Br
+ 		"config-observability",
  		"config-features",
  		"kafka-config-logging",
 +		"config-openshift-trusted-cabundle",


### PR DESCRIPTION
## Summary
- Fixed the `namespaced_broker_copy_trustedca_cm.patch` to work with upstream changes
- Updated patch context from `config-tracing` to `config-observability` 
- Fixed line numbers and context to match current upstream code structure

## Test plan
- [x] Verified patch applies cleanly to current upstream code
- [x] Tested patch application locally without errors
- [x] Confirmed all existing functionality preserved

## Background
The nightly CI job `knative-nightly-ci-eventing-kafka-broker` was failing because the patch could not be applied. The upstream `knative-extensions/eventing-kafka-broker` repository changed the `configMapsFromSystemNamespace` function to use `config-observability` instead of `config-tracing`, but the downstream patch was still looking for the old context.

This change updates the patch to work with the current upstream code structure while preserving the functionality of copying the `config-openshift-trusted-cabundle` ConfigMap.

🤖 Generated with [Claude Code](https://claude.ai/code)