### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for kn-ekb-dispatcher-116

### DIFF
--- a/openshift/ci-operator/static-images/dispatcher/hermetic/Dockerfile
+++ b/openshift/ci-operator/static-images/dispatcher/hermetic/Dockerfile
@@ -41,8 +41,9 @@ USER 185
 
 LABEL \
       com.redhat.component="openshift-serverless-1-eventing-kafka-broker-dispatcher-rhel8-container" \
-      name="openshift-serverless-1/eventing-kafka-broker-dispatcher-rhel8" \
+      name="openshift-serverless-1/kn-ekb-dispatcher-rhel8" \
       version=$VERSION \
+      cpe="cpe:/a:redhat:openshift_serverless:1.36::el8" \
       release=$VERSION \
       summary="Red Hat OpenShift Serverless 1 Eventing Kafka Broker Dispatcher" \
       maintainer="serverless-support@redhat.com" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
