### PR TITLE
[release-v1.17] fix SO on-cluster builds namespace move

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -92,7 +92,7 @@ EOF
   local failed=0
   pushd $operator_dir || return $?
   export ON_CLUSTER_BUILDS=true
-  export DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-marketplace
+  export DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-serverless-builds
   if [[ ${INSTALL_KEDA} == "true" ]]; then
   	make OPENSHIFT_CI="true" TRACING_BACKEND=zipkin \
 	    generated-files images install-tracing install-kafka-with-keda || failed=$?


### PR DESCRIPTION
Since https://github.com/openshift-knative/serverless-operator/commit/083f319e5303ea3d4f0e0ab95eaa39795fc6b8cb we use `openshift-serverless-builds` namespace for on-cluster builds in SO