### PR TITLE
Don't set CPE labels on release-next builds

### DIFF
--- a/openshift/generate.sh
+++ b/openshift/generate.sh
@@ -10,6 +10,12 @@ GOFLAGS='' go run github.com/openshift-knative/hack/cmd/generate@latest \
 
 # Update CPE labels in the static Dockerfiles with computed versions
 release=$(yq r "${repo_root_dir}/openshift/project.yaml" project.tag)
+
+# Skip label updates for release-next builds
+if [ "${release}" = "knative-nightly" ]; then
+  exit 0
+fi
+
 release=${release/knative-/}
 
 so_branch=$( GOFLAGS='' go run github.com/openshift-knative/hack/cmd/sobranch@latest --upstream-version "${release}")


### PR DESCRIPTION
Currently we see the following error in the update-to-head [jobs](hhttps://jenkins-csb-serverless-qe-master.dno.corp.redhat.com/job/ci/job/knative-nightly-ci-eventing-kafka-broker/1365/console):
```
10:49:27  panic: nightly is not in dotted-tri format
10:49:27  
10:49:27  goroutine 1 [running]:
10:49:27  github.com/coreos/go-semver/semver.Must(...)
10:49:27  	/home/jenkins/go/pkg/mod/github.com/coreos/go-semver@v0.3.0/semver/semver.go:65
10:49:27  github.com/coreos/go-semver/semver.New({0x7fff0493c13b?, 0x7?})
10:49:27  	/home/jenkins/go/pkg/mod/github.com/coreos/go-semver@v0.3.0/semver/semver.go:49 +0x2f
10:49:27  github.com/openshift-knative/hack/pkg/soversion.FromUpstreamVersion({0x7fff0493c13b?, 0xc000012670?})
10:49:27  	/home/jenkins/go/pkg/mod/github.com/openshift-knative/hack@v0.0.0-20260303083152-80ff9f8eed6e/pkg/soversion/version.go:19 +0xec
10:49:27  main.main()
10:49:27  	/home/jenkins/go/pkg/mod/github.com/openshift-knative/hack@v0.0.0-20260303083152-80ff9f8eed6e/cmd/sobranch/sobranch.go:14 +0x96
10:49:27  exit status 2
10:49:27  make: *** [Makefile:73: generate-release] Error 1
```

This is because we can't determine the SO version and coresponding RHEL version on release-next branch. As this is anyhow only needed for the konflux CPE labels, we can skip this on release-next.