### PR TITLE
[release-v1.21] Use lower case tag names for metrics (#4661)

### DIFF
--- a/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/observability/metrics/Metrics.java
+++ b/data-plane/core/src/main/java/dev/knative/eventing/kafka/broker/core/observability/metrics/Metrics.java
@@ -160,8 +160,8 @@ public class Metrics {
         public static io.micrometer.core.instrument.Tags resourceTags(
                 final String resourceKind, final String resourceName, final String resourceNamespace) {
             return io.micrometer.core.instrument.Tags.of(
-                    Tag.of(String.format(RESOURCE_NAME_TEMPLATE, resourceKind), resourceName),
-                    Tag.of(String.format(RESOURCE_NAMESPACE_TEMPLATE, resourceKind), resourceNamespace));
+                    Tag.of(String.format(RESOURCE_NAME_TEMPLATE, resourceKind.toLowerCase()), resourceName),
+                    Tag.of(String.format(RESOURCE_NAMESPACE_TEMPLATE, resourceKind.toLowerCase()), resourceNamespace));
         }
     }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/knative-extensions/eventing-kafka-broker/pull/4661/changes to avoid tags like `kn_KafkaChannel_namespace`